### PR TITLE
add `shareProcessNamespace` to Values

### DIFF
--- a/charts/access-request/Chart.yaml
+++ b/charts/access-request/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/access-request/templates/deployment.yml
+++ b/charts/access-request/templates/deployment.yml
@@ -21,6 +21,7 @@ spec:
         sidecar.istio.io/inject: "true"
     spec:
       serviceAccountName: {{ .Release.Name }}
+      shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       containers:
       - image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
         {{- include "ghga-common.command-args" (list "ars")  | nindent 8 }}

--- a/charts/access-request/values.yaml
+++ b/charts/access-request/values.yaml
@@ -55,3 +55,5 @@ parameters:
   service_instance_id: 'ars_1'
   service_name: ars
   workers: 1
+
+shareProcessNamespace: false

--- a/charts/auth-service/Chart.yaml
+++ b/charts/auth-service/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/auth-service/templates/deployment.yml
+++ b/charts/auth-service/templates/deployment.yml
@@ -21,6 +21,7 @@ spec:
         sidecar.istio.io/inject: "true"
     spec:
       serviceAccountName: {{ .Release.Name }}
+      shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       containers:
       - image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
         {{- include "ghga-common.command-args" (list "auth-service")  | nindent 8 }}

--- a/charts/auth-service/values.yaml
+++ b/charts/auth-service/values.yaml
@@ -79,3 +79,5 @@ authService:
   emissary:
     enabled: false
     name: authentication
+
+shareProcessNamespace: false

--- a/charts/data-portal-ui/Chart.yaml
+++ b/charts/data-portal-ui/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/data-portal-ui/templates/deployment.yml
+++ b/charts/data-portal-ui/templates/deployment.yml
@@ -21,6 +21,7 @@ spec:
         version: staging
     spec:
       serviceAccountName: {{ .Release.Name }}
+      shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       containers:
       - image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
         {{- include "ghga-common.command-args" (list "python /service/configure_build_serve/run.py")  | nindent 8 }}

--- a/charts/data-portal-ui/values.yaml
+++ b/charts/data-portal-ui/values.yaml
@@ -29,3 +29,5 @@ parameters:
   port: 8080
   svc_repository_url: "/api/repository"
   svc_search_url: "/api/search"
+
+shareProcessNamespace: false

--- a/charts/download-controller/Chart.yaml
+++ b/charts/download-controller/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/download-controller/templates/deployment.yml
+++ b/charts/download-controller/templates/deployment.yml
@@ -21,6 +21,7 @@ spec:
         sidecar.istio.io/inject: "true"
     spec:
       serviceAccountName: {{ .Release.Name }}
+      shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       containers:
       - image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
         {{- include "ghga-common.command-args" (list "dcs run-rest")  | nindent 8 }}

--- a/charts/download-controller/values.yaml
+++ b/charts/download-controller/values.yaml
@@ -80,3 +80,5 @@ parameters:
     service_instance_id: 'dcs_rest_1'
   consumer:
     service_instance_id: 'dcs_consumer_1'
+
+shareProcessNamespace: false

--- a/charts/encryption-key-store/Chart.yaml
+++ b/charts/encryption-key-store/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/encryption-key-store/templates/deployment.yml
+++ b/charts/encryption-key-store/templates/deployment.yml
@@ -21,6 +21,7 @@ spec:
         sidecar.istio.io/inject: "true"
     spec:
       serviceAccountName: {{ .Release.Name }}
+      shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       containers:
       - image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
         {{- include "ghga-common.command-args" (list "ekss")  | nindent 8 }}

--- a/charts/encryption-key-store/values.yaml
+++ b/charts/encryption-key-store/values.yaml
@@ -46,3 +46,5 @@ parameters:
   vault_role_id: '**********'
   vault_secret_id: '**********'
   workers: 1
+
+shareProcessNamespace: false

--- a/charts/file-ingest/Chart.yaml
+++ b/charts/file-ingest/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/file-ingest/templates/deployment.yml
+++ b/charts/file-ingest/templates/deployment.yml
@@ -21,6 +21,7 @@ spec:
         sidecar.istio.io/inject: "true"
     spec:
       serviceAccountName: {{ .Release.Name }}
+      shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       containers:
       - image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
         {{- include "ghga-common.command-args" (list "fis")  | nindent 8 }}

--- a/charts/file-ingest/values.yaml
+++ b/charts/file-ingest/values.yaml
@@ -51,3 +51,5 @@ parameters:
   vault_role_id: '**********'
   vault_secret_id: '**********'
   workers: 1
+
+shareProcessNamespace: false

--- a/charts/internal-file-registry/Chart.yaml
+++ b/charts/internal-file-registry/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/internal-file-registry/templates/deployment.yml
+++ b/charts/internal-file-registry/templates/deployment.yml
@@ -21,6 +21,7 @@ spec:
         sidecar.istio.io/inject: "true"
     spec:
       serviceAccountName: {{ .Release.Name }}
+      shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       containers:
       - image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
         {{- include "ghga-common.command-args" (list "ifrs")  | nindent 8 }}

--- a/charts/internal-file-registry/values.yaml
+++ b/charts/internal-file-registry/values.yaml
@@ -49,3 +49,5 @@ parameters:
   s3_session_token: "**********"
   service_instance_id: "ifrs_1"
   service_name: internal_file_registry
+
+shareProcessNamespace: false

--- a/charts/metadata-repository/Chart.yaml
+++ b/charts/metadata-repository/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/metadata-repository/templates/deployment.yml
+++ b/charts/metadata-repository/templates/deployment.yml
@@ -21,6 +21,7 @@ spec:
         sidecar.istio.io/inject: "true"
     spec:
       serviceAccountName: {{ .Release.Name }}
+      shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       containers:
       - image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
         {{- include "ghga-common.command-args" (list "metadata-repository-service")  | nindent 8 }}

--- a/charts/metadata-repository/values.yaml
+++ b/charts/metadata-repository/values.yaml
@@ -39,3 +39,5 @@ parameters:
   openapi_url: /openapi.json
   port: 8080
   workers: 1
+
+shareProcessNamespace: false

--- a/charts/metadata-search/Chart.yaml
+++ b/charts/metadata-search/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/metadata-search/templates/deployment.yml
+++ b/charts/metadata-search/templates/deployment.yml
@@ -21,6 +21,7 @@ spec:
         sidecar.istio.io/inject: "true"
     spec:
       serviceAccountName: {{ .Release.Name }}
+      shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       containers:
       - image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
         {{- include "ghga-common.command-args" (list "metadata-search-service")  | nindent 8 }}

--- a/charts/metadata-search/values.yaml
+++ b/charts/metadata-search/values.yaml
@@ -32,7 +32,7 @@ parameters:
   cors_allowed_methods: []
   cors_allowed_origins: []
   db_name: metadata-store
-  db_url:  "**********"
+  db_url: "**********"
   docs_url: /docs
   host: 0.0.0.0
   log_level: info

--- a/charts/metadata-search/values.yaml
+++ b/charts/metadata-search/values.yaml
@@ -39,3 +39,5 @@ parameters:
   openapi_url: /openapi.json
   port: 8080
   workers: 1
+
+shareProcessNamespace: false

--- a/charts/metldata/Chart.yaml
+++ b/charts/metldata/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/metldata/templates/deployment.yml
+++ b/charts/metldata/templates/deployment.yml
@@ -21,6 +21,7 @@ spec:
         sidecar.istio.io/inject: "true"
     spec:
       serviceAccountName: {{ .Release.Name }}
+      shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       containers:
       - image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
         {{- include "ghga-common.command-args" (list "metldata")  | nindent 8 }}

--- a/charts/metldata/values.yaml
+++ b/charts/metldata/values.yaml
@@ -41,3 +41,5 @@ parameters:
   openapi_url: /openapi.json
   port: 8080
   workers: 1
+
+shareProcessNamespace: false

--- a/charts/metldata/values.yaml
+++ b/charts/metldata/values.yaml
@@ -36,7 +36,7 @@ parameters:
   db_name: metadata_artifacts
   docs_url: /docs
   host: 0.0.0.0
-  loader_token_hashes: "**********" # <Please fill - The tokens must be the loader token generated using the data steward kit.>
+  loader_token_hashes: "**********"  # <Please fill - The tokens must be the loader token generated using the data steward kit.>
   log_level: info
   openapi_url: /openapi.json
   port: 8080

--- a/charts/test-oidc-provider/Chart.yaml
+++ b/charts/test-oidc-provider/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/test-oidc-provider/templates/deployment.yml
+++ b/charts/test-oidc-provider/templates/deployment.yml
@@ -21,6 +21,7 @@ spec:
         sidecar.istio.io/inject: "true"
     spec:
       serviceAccountName: {{ .Release.Name }}
+      shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       containers:
       - image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
         {{- include "ghga-common.command-args" (list "top")  | nindent 8 }}

--- a/charts/test-oidc-provider/values.yaml
+++ b/charts/test-oidc-provider/values.yaml
@@ -34,3 +34,5 @@ parameters:
   user_domain: home.org
   valid_seconds: 3600
   workers: 1
+
+shareProcessNamespace: false

--- a/charts/work-package/Chart.yaml
+++ b/charts/work-package/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: 0.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/work-package/templates/deployment.yml
+++ b/charts/work-package/templates/deployment.yml
@@ -21,6 +21,7 @@ spec:
         sidecar.istio.io/inject: "true"
     spec:
       serviceAccountName: {{ .Release.Name }}
+      shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       containers:
       - image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
         {{- include "ghga-common.command-args" (list "wps run-rest")  | nindent 8 }}

--- a/charts/work-package/values.yaml
+++ b/charts/work-package/values.yaml
@@ -63,3 +63,5 @@ parameters:
     service_instance_id: 'wps_rest_1'
   consumer:
     service_instance_id: 'wps_consumer_1'
+
+shareProcessNamespace: false


### PR DESCRIPTION
Add `shareProcessNamespace` to Values in order to prepare usage of Vault's MongoDB plugin. Vault's agent sidecar needs to be able to kill processes in application container.