### PR TITLE
A new script to check configured versions against latest releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 charts/**/charts/*.tgz
-.idea
+
+.idea/
+.vscode/
+
+.DS_Store
+desktop.ini
+thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 charts/**/charts/*.tgz
+.idea

--- a/scripts/check_release_versions.sh
+++ b/scripts/check_release_versions.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-# This script checks for updates in GHGA GitHub repositories based on service configurations in the charts/ directory, 
-# reporting services with new releases and those skipped due to specific criteria or missing information.
+# This script checks for updates in GHGA GitHub repositories based on service configurations in the charts/ directory, reporting services with new releases and those skipped due to specific criteria or missing information.
 
 # Base directory for charts
 CHARTS_DIR="charts"

--- a/scripts/check_release_versions.sh
+++ b/scripts/check_release_versions.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# This script checks for updates in GHGA GitHub repositories based on service configurations in the charts/ directory, 
+# reporting services with new releases and those skipped due to specific criteria or missing information.
+
+# Base directory for charts
+CHARTS_DIR="charts"
+
+# Optional GitHub token to increase API rate limit
+TOKEN=""
+
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --token) TOKEN="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+has_values_yaml(){
+ [[ -f "$1/values.yaml" ]]
+}
+
+# Extract appVersion from Chart.yaml
+extract_app_version() {
+    grep 'appVersion:' "$1/Chart.yaml" | cut -d '"' -f 2
+}
+
+# Extract GitHub repository name from values.yaml
+extract_github_repo_name(){
+    grep 'image:' -A 1 "$1/values.yaml" | tail -n1 | awk -F'/' '{gsub(/"/, "", $2); print $2}'       
+}
+
+# Get the latest release version from GitHub API
+get_latest_github_release() {
+
+    local curl_cmd="curl -s \"https://api.github.com/repos/ghga-de/$1/releases/latest\""
+    if [ -n "$TOKEN" ]; then
+        curl_cmd+=" --header \"Authorization: Bearer $TOKEN\""
+    fi
+    local response=$(eval "$curl_cmd")
+
+    if echo "$response" | grep -q 'rate limit exceeded'; then
+        echo "RateLimitExceeded"
+    elif echo "$response" | grep -q 'Not Found'; then
+        echo "NotFound"
+    else
+        echo "$response" | grep 'tag_name' | cut -d '"' -f 4
+    fi
+}
+
+declare -a skipped_services
+declare -a updated_services
+
+for service in "$CHARTS_DIR"/*; do
+    if [[ -d "$service" ]] && has_values_yaml "$service"; then
+        service_name=$(basename "$service")
+        github_repo_name=$(extract_github_repo_name "$service")
+
+        configured_version=$(extract_app_version "$service")
+        latest_version="$(get_latest_github_release "$github_repo_name")"
+
+        # If API Rate limit exceeded, exit
+        if [ "$latest_version" == "RateLimitExceeded" ]; then
+            echo "API Rate limit exceeded"
+            exit 1
+        fi
+        
+        # If the GitHub API returns 404
+        if [ "$latest_version" == "NotFound" ]; then    
+            # If service has no release, skip
+            if [[ "$configured_version" == "0.0.0" ]]; then
+                skipped_services+=("$service_name: No release (0.0.0)")
+            else
+                skipped_services+=("$service_name: Repository not found")
+            fi
+            continue
+        fi
+
+        if [ "$latest_version" != "$configured_version" ]; then
+            updated_services+=("$service_name: $configured_version > $latest_version")
+        fi
+    else
+        skipped_services+=("$service: values.yaml not found")
+    fi
+done
+
+# Report skipped services
+echo "Skipped:"
+for service in "${skipped_services[@]}"; do
+    echo " $service"
+done
+
+# Report updated services
+echo "New release available:"
+for service in "${updated_services[@]}"; do
+    echo " $service"
+done

--- a/scripts/check_release_versions.sh
+++ b/scripts/check_release_versions.sh
@@ -16,6 +16,8 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
+cd "$(dirname "$0")/.."
+
 has_values_yaml(){
  [[ -f "$1/values.yaml" ]]
 }
@@ -77,7 +79,7 @@ for service in "$CHARTS_DIR"/*; do
         fi
 
         if [ "$latest_version" != "$configured_version" ]; then
-            updated_services+=("$service_name: $configured_version > $latest_version")
+            updated_services+=("$service_name: $configured_version < $latest_version")
         fi
     else
         skipped_services+=("$service: values.yaml not found")


### PR DESCRIPTION
This PR adds a simple bash script to check configured service versions against their latest releases and creates a report. 

- Since this is not a Python project I've added it as bash script. 
- We don't have the actual service repository URL or repository names in this repo, I've used the image name in values.yaml, it works for most of the services.
- GitHub Rest API has rate limit of 60 requests/hour, just in case I've added an optional token parameter to extend rate limits with a GitHub token.