### PR TITLE
Add KafkaUser CRDs to streamline Strimzi configuration

### DIFF
--- a/charts/access-request/templates/kafkauser.yml
+++ b/charts/access-request/templates/kafkauser.yml
@@ -1,0 +1,19 @@
+{{ if .Values.strimzi.enabled }}
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    strimzi.io/cluster: {{ .Values.strimzi.name }}
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: {{ .Values.parameters.notification_event_topic }}
+          patternType: literal
+        operation: Write
+{{ end }}

--- a/charts/access-request/values.yaml
+++ b/charts/access-request/values.yaml
@@ -25,6 +25,10 @@ mapping:
   prefix: /
   rewrite: null
 
+strimzi:
+  enabled: false
+  name: "kafka"
+
 parameters:
   api_root_path: ""
   auth_algs:
@@ -47,8 +51,9 @@ parameters:
   docs_url: /docs
   download_access_url: http://claims-repository-svc:8080/download-access
   host: "0.0.0.0"
-  kafka_servers:
-  - kafka-kafka-bootstrap:9092
+  kafka_servers: []
+  notification_event_topic: notifications
+  notification_event_type: notification
   log_level: info
   openapi_url: /openapi.json
   port: 8080

--- a/charts/download-controller/templates/kafkauser.yml
+++ b/charts/download-controller/templates/kafkauser.yml
@@ -1,0 +1,44 @@
+{{ if .Values.strimzi.enabled }}
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    strimzi.io/cluster: {{ .Values.strimzi.name }}
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: {{ .Values.parameters.default.download_served_event_topic }}
+          patternType: literal
+        operation: ReadWrite
+      - resource:
+          type: topic
+          name: {{ .Values.parameters.default.file_deleted_event_topic }}
+          patternType: literal
+        operation: ReadWrite
+      - resource:
+          type: topic
+          name: {{ .Values.parameters.default.file_registered_event_topic }}
+          patternType: literal
+        operation: ReadWrite
+      - resource:
+          type: topic
+          name: {{ .Values.parameters.default.unstaged_download_event_topic }}
+          patternType: literal
+        operation: ReadWrite
+      - resource:
+          type: topic
+          name: {{ .Values.parameters.default.files_to_delete_topic }}
+          patternType: literal
+        operation: ReadWrite
+      - resource:
+          type: topic
+          name: {{ .Values.parameters.default.files_to_register_topic }}
+          patternType: literal
+        operation: ReadWrite
+{{ end }}

--- a/charts/download-controller/values.yaml
+++ b/charts/download-controller/values.yaml
@@ -24,6 +24,10 @@ mapping:
   hostname: ""
   prefix: /
 
+strimzi:
+  enabled: false
+  name: "kafka"
+
 parameters:
   default:
     api_root_path: /
@@ -59,7 +63,7 @@ parameters:
     files_to_delete_type: files_to_delete
     files_to_register_topic: internal_registrations
     files_to_register_type: internal_file_registered
-    host: 127.0.0.1
+    host: "0.0.0.0"
     kafka_servers: []
     log_level: info
     openapi_url: /openapi.json

--- a/charts/file-ingest/templates/kafkauser.yml
+++ b/charts/file-ingest/templates/kafkauser.yml
@@ -1,0 +1,19 @@
+{{ if .Values.strimzi.enabled }}
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    strimzi.io/cluster: {{ .Values.strimzi.name }}
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: {{ .Values.parameters.publisher_topic }}
+          patternType: literal
+        operation: ReadWrite
+{{ end }}

--- a/charts/file-ingest/values.yaml
+++ b/charts/file-ingest/values.yaml
@@ -25,6 +25,10 @@ mapping:
   prefix: /
   rewrite: null
 
+strimzi:
+  enabled: false
+  name: "kafka"
+
 parameters:
   api_root_path: /
   auto_reload: false

--- a/charts/internal-file-registry/templates/kafkauser.yml
+++ b/charts/internal-file-registry/templates/kafkauser.yml
@@ -1,0 +1,44 @@
+{{ if .Values.strimzi.enabled }}
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    strimzi.io/cluster: {{ .Values.strimzi.name }}
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: {{ .Values.parameters.file_deleted_event_topic }}
+          patternType: literal
+        operation: ReadWrite
+      - resource:
+          type: topic
+          name: {{ .Values.parameters.file_registered_event_topic }}
+          patternType: literal
+        operation: ReadWrite
+      - resource:
+          type: topic
+          name: {{ .Values.parameters.file_staged_event_topic }}
+          patternType: literal
+        operation: ReadWrite
+      - resource:
+          type: topic
+          name: {{ .Values.parameters.files_to_delete_topic }}
+          patternType: literal
+        operation: ReadWrite
+      - resource:
+          type: topic
+          name: {{ .Values.parameters.files_to_register_topic }}
+          patternType: literal
+        operation: ReadWrite
+      - resource:
+          type: topic
+          name: {{ .Values.parameters.files_to_stage_topic }}
+          patternType: literal
+        operation: ReadWrite
+{{ end }}

--- a/charts/internal-file-registry/values.yaml
+++ b/charts/internal-file-registry/values.yaml
@@ -25,6 +25,10 @@ mapping:
   prefix: /
   rewrite: null
 
+strimzi:
+  enabled: false
+  name: "kafka"
+
 parameters:
   aws_config_ini: null
   db_connection_str: "**********"

--- a/charts/work-package/templates/kafkauser.yml
+++ b/charts/work-package/templates/kafkauser.yml
@@ -1,0 +1,19 @@
+{{ if .Values.strimzi.enabled }}
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    strimzi.io/cluster: {{ .Values.strimzi.name }}
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: {{ .Values.parameters.default.dataset_change_event_topic }}
+          patternType: literal
+        operation: ReadWrite
+{{ end }}

--- a/charts/work-package/values.yaml
+++ b/charts/work-package/values.yaml
@@ -24,6 +24,10 @@ mapping:
   hostname: ""
   prefix: /
 
+strimzi:
+  enabled: false
+  name: "kafka"
+
 parameters:
   default:
     api_root_path: /
@@ -41,8 +45,9 @@ parameters:
     cors_allowed_headers: []
     cors_allowed_methods: []
     cors_allowed_origins: []
-    dataset_overview_event_topic: metadata
-    dataset_overview_event_type: metadata_dataset_overview
+    dataset_change_event_topic: metadata_datasets
+    dataset_upsertion_event_type: dataset_created
+    dataset_deletion_event_type: dataset_deleted
     datasets_collection: datasets
     db_connection_str: "**********"
     db_name: wps


### PR DESCRIPTION
This PR introduces a series of updates to the KafkaUser resource configurations in various Helm charts within our project. These changes are primarily focused on integrating TLS-based authentication and fine-tuning ACLs for topic access control. A summary of the modifications across different charts is provided below:

1. **Access Request Chart:**
   - Added a new `KafkaUser` configuration in `charts/access-request/templates/kafkauser.yml` with 19 additions. 
   - The user is configured with TLS authentication and write access to the `{{ .Values.parameters.notification_event_topic }}`.
   - Updated `values.yaml` with relevant Strimzi and parameters configurations.

2. **Download Controller Chart:**
   - Introduced a comprehensive `KafkaUser` setup in `charts/download-controller/templates/kafkauser.yml` with 44 additions.
   - Configured multiple ACLs for ReadWrite operations on various topics like `download_served_event_topic`, `file_deleted_event_topic`, etc.
   - Minor updates in `values.yaml` to support these configurations.

3. **File Ingest Chart:**
   - Implemented a `KafkaUser` resource in `charts/file-ingest/templates/kafkauser.yml` with 19 additions.
   - The user is set up for ReadWrite access on the `publisher_topic`.
   - Adjustments made in `values.yaml` to align with these new settings.

4. **Internal File Registry Chart:**
   - Added a detailed `KafkaUser` configuration in `charts/internal-file-registry/templates/kafkauser.yml` with 44 additions.
   - Configured ReadWrite ACLs for multiple topics including `file_staged_event_topic`, `files_to_delete_topic`, etc.
   - Updated `values.yaml` to reflect these new parameters.

5. **Work Package Chart:**
   - Created a new `KafkaUser` resource in `charts/work-package/templates/kafkauser.yml` with 19 additions.
   - Configured for ReadWrite operations on the `dataset_change_event_topic`.
   - Made necessary updates in `values.yaml` for supporting configurations.

#### Highlights:
- All `KafkaUser` resources utilize TLS authentication.
- ACLs are carefully set for specific topic access, enhancing security and access control.
- The `values.yaml` files in each chart are updated to reflect the new configurations and align with the Strimzi cluster settings.

#### Impact:
These changes are pivotal for strengthening the security posture of our Kafka setup and ensuring fine-grained access control to various Kafka topics across different components of our system. It aligns with our goals of robustness and scalability in handling event-driven architectures.

---

Please review the changes for accuracy, compliance with our coding standards, and alignment with our architectural goals. Your insights and feedback are highly valued.