### PR TITLE
Remove unused port definition

### DIFF
--- a/charts/mongodb-s3-backup/templates/cronjob.yaml
+++ b/charts/mongodb-s3-backup/templates/cronjob.yaml
@@ -23,10 +23,6 @@ spec:
             - name: {{ .Chart.Name }}
               imagePullPolicy: {{ .Values.image.pullPolicy }} 
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-              ports:
-                - name: http
-                  containerPort: {{ .Values.service.port }}
-                  protocol: TCP
               envFrom:
                 - configMapRef:
                     name: {{ include "mongodb-s3-backup.fullname" . }}


### PR DESCRIPTION
The mongodb-s3-backup does not open any ports, so the PodSpec does not need any port definition.