### PR TITLE
Prepare services to Archive 1.0 release

### DIFF
--- a/charts/access-request/Chart.yaml
+++ b/charts/access-request/Chart.yaml
@@ -5,13 +5,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.2"
+appVersion: "2.0.0"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.

--- a/charts/access-request/Chart.yaml
+++ b/charts/access-request/Chart.yaml
@@ -11,7 +11,7 @@ version: 1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.0"
+appVersion: "2.0.1"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.

--- a/charts/access-request/values.yaml
+++ b/charts/access-request/values.yaml
@@ -48,6 +48,7 @@ parameters:
       exp: null
       iat: null
       name: null
+      id: null
     auth_key: '{}'
     auth_map_claims: {}
     auto_reload: true
@@ -63,12 +64,18 @@ parameters:
     host: "0.0.0.0"
     kafka_servers:
     - kafka-kafka-bootstrap:9092
-
-    notification_event_topic: notifications
-    notification_event_type: notification
+    kafka_security_protocol: PLAINTEXT
+    kafka_ssl_cafile: null
+    kafka_ssl_certfile: null
+    kafka_ssl_keyfile: null
+    kafka_ssl_password: null
+    access_request_events_topic: access_request_events
+    access_request_created_event_type: access_request_created
+    access_request_allowed_event_type: access_request_allowed
+    access_request_denied_event_type: access_request_denied
     openapi_url: /openapi.json
     port: 8080
-    service_instance_id: 'ars_1'
+    service_instance_id: 'rest.1'
     service_name: ars
     workers: 1
 

--- a/charts/auth-service/Chart.yaml
+++ b/charts/auth-service/Chart.yaml
@@ -5,13 +5,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.6"
+appVersion: "2.3.0"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.

--- a/charts/auth-service/values.yaml
+++ b/charts/auth-service/values.yaml
@@ -44,7 +44,7 @@ parameters:
     # Injected through Vault
     auth_ext_keys: null
     auth_key: null
-    db_url: null
+    db_connection_str: null
 
     # Required for auth-adapter only and injected through Vault
     basic_auth_credentials: null
@@ -56,7 +56,7 @@ parameters:
 
     add_as_data_stewards: []
     api_ext_path: /api/auth
-    api_root_path: /
+    api_root_path: ''
     auth_algs:
     - ES256
     auth_check_claims:
@@ -64,6 +64,7 @@ parameters:
       exp: null
       iat: null
       name: null
+      id: null
     auth_ext_algs:
     - RS256
     - ES256
@@ -79,12 +80,25 @@ parameters:
     docs_url: /docs
     host: 0.0.0.0
 
+    dataset_deletion_event_topic: metadata_datasets
+    dataset_deletion_event_type: dataset_deleted
+
     openapi_url: /openapi.json
-    organization_url: https://ghga.de
+    organization_url: https://ghga.de/
     port: 8080
     service_name: auth_service
     users_collection: users
+    user_tokens_collection: user_tokens
     workers: 1
+
+    kafka_servers: []
+    kafka_security_protocol: PLAINTEXT
+    kafka_ssl_cafile: null
+    kafka_ssl_certfile: null
+    kafka_ssl_keyfile: null
+    kafka_ssl_password: null
+
+    ivas_collection: ivas
 
 authService:
   emissary:

--- a/charts/download-controller/Chart.yaml
+++ b/charts/download-controller/Chart.yaml
@@ -5,13 +5,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.6.4"
+appVersion: "1.1.0"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.

--- a/charts/download-controller/values.yaml
+++ b/charts/download-controller/values.yaml
@@ -76,24 +76,34 @@ parameters:
     files_to_register_type: internal_file_registered
     host: "0.0.0.0"
     kafka_servers: []
+    kafka_security_protocol: PLAINTEXT
+    kafka_ssl_cafile: null
+    kafka_ssl_certfile: null
+    kafka_ssl_keyfile: null
+    kafka_ssl_password: null
 
     openapi_url: /openapi.json
     outbox_bucket: outbox
     port: 8080
     presigned_url_expires_after: 10
     retry_access_after: 120
-    s3_access_key_id: null
-    s3_endpoint_url: null
-    s3_secret_access_key: null
-    s3_session_token: null
+    object_storages:
+      test:
+        bucket: outbox
+        credentials:
+          aws_config_ini: null
+          s3_endpoint_url: null
+          s3_access_key_id: null
+          s3_secret_access_key: null
+          s3_session_token: null
     service_instance_id: 'dcs_1'
     service_name: dcs
     unstaged_download_event_topic: downloads
     unstaged_download_event_type: unstaged_drs_object_requested
     workers: 1
   rest:
-    service_instance_id: 'dcs_rest_1'
+    service_instance_id: 'rest.1'
   consumer:
-    service_instance_id: 'dcs_consumer_1'
+    service_instance_id: 'consumer.1'
 
 shareProcessNamespace: false

--- a/charts/encryption-key-store/Chart.yaml
+++ b/charts/encryption-key-store/Chart.yaml
@@ -5,13 +5,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.9"
+appVersion: "1.0.1"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.

--- a/charts/encryption-key-store/values.yaml
+++ b/charts/encryption-key-store/values.yaml
@@ -38,6 +38,8 @@ parameters:
     vault_verify: false
     vault_role_id: null
     vault_secret_id: null
+    vault_path: ekss
+    vault_kube_role: null
     workers: 1
 
 shareProcessNamespace: false

--- a/charts/file-ingest/Chart.yaml
+++ b/charts/file-ingest/Chart.yaml
@@ -5,13 +5,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.5"
+appVersion: "1.1.1"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.

--- a/charts/file-ingest/values.yaml
+++ b/charts/file-ingest/values.yaml
@@ -37,7 +37,7 @@ mapping:
 
 parameters:
   default:
-    api_root_path: /
+    api_root_path: ""
     auto_reload: false
     cors_allow_credentials: false
     cors_allowed_headers: []
@@ -46,13 +46,18 @@ parameters:
     docs_url: /docs
     host: 0.0.0.0
     kafka_servers: []
+    kafka_security_protocol: PLAINTEXT
+    kafka_ssl_cafile: null
+    kafka_ssl_certfile: null
+    kafka_ssl_keyfile: null
+    kafka_ssl_password: null
 
     openapi_url: /openapi.json
     port: 8080
     private_key: ""
     publisher_topic: interrogations
     publisher_type: validation_success
-    service_instance_id: "fis_1"
+    service_instance_id: rest.1
     service_name: fis
     source_bucket_id: staging
     token_hashes: []
@@ -60,6 +65,9 @@ parameters:
     vault_verify: false
     vault_role_id: null
     vault_secret_id: null
+    vault_path: ekss
+    vault_kube_role: null
     workers: 1
+    selected_storage_alias: staging
 
 shareProcessNamespace: false

--- a/charts/internal-file-registry/Chart.yaml
+++ b/charts/internal-file-registry/Chart.yaml
@@ -5,13 +5,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.0"
+appVersion: "1.1.0"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.

--- a/charts/internal-file-registry/values.yaml
+++ b/charts/internal-file-registry/values.yaml
@@ -35,12 +35,20 @@ parameters:
     files_to_stage_topic: downloads
     files_to_stage_type: unstaged_drs_object_requested
     kafka_servers: []
-    permanent_bucket: permanent
-    s3_access_key_id: null
-    s3_endpoint_url: null
-    s3_secret_access_key: null
-    s3_session_token: null
-    service_instance_id: "ifrs_1"
+    kafka_security_protocol: PLAINTEXT
+    kafka_ssl_cafile: null
+    kafka_ssl_certfile: null
+    kafka_ssl_keyfile: null
+    kafka_ssl_password: null
+    service_instance_id: "consumer.1"
     service_name: internal_file_registry
+    object_storages:
+      test:
+        bucket: permanent
+        credentials:
+          s3_access_key_id: null
+          s3_endpoint_url: null
+          s3_secret_access_key: null
+          s3_session_token: null
 
 shareProcessNamespace: false

--- a/charts/mass/Chart.yaml
+++ b/charts/mass/Chart.yaml
@@ -5,13 +5,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.5"
+appVersion: "1.0.1"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.

--- a/charts/mass/values.yaml
+++ b/charts/mass/values.yaml
@@ -49,6 +49,11 @@ parameters:
     host: "0.0.0.0"
     kafka_servers:
     - kafka:9092
+    kafka_security_protocol: PLAINTEXT
+    kafka_ssl_cafile: null
+    kafka_ssl_certfile: null
+    kafka_ssl_keyfile: null
+    kafka_ssl_password: null
 
     openapi_url: /openapi.json
     port: 8080
@@ -66,8 +71,8 @@ parameters:
     service_name: mass
     workers: 1
   rest:
-    service_instance_id: 'mass_rest_1'
+    service_instance_id: 'rest.1'
   consumer:
-    service_instance_id: 'mass_consumer_1'
+    service_instance_id: 'consumer.1'
 
 shareProcessNamespace: false

--- a/charts/metldata/Chart.yaml
+++ b/charts/metldata/Chart.yaml
@@ -5,13 +5,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.5"
+appVersion: "1.2.1"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.

--- a/charts/metldata/values.yaml
+++ b/charts/metldata/values.yaml
@@ -54,6 +54,11 @@ parameters:
     host: 0.0.0.0
     kafka_servers:
     - kafka:9092
+    kafka_security_protocol: PLAINTEXT
+    kafka_ssl_cafile: null
+    kafka_ssl_certfile: null
+    kafka_ssl_keyfile: null
+    kafka_ssl_password: null
     loader_token_hashes: null  # <Please fill - The tokens must be the loader token generated using the data steward kit.>
 
     openapi_url: /openapi.json
@@ -63,7 +68,7 @@ parameters:
     resource_change_event_topic: searchable_resources
     resource_deletion_event_type: searchable_resource_deleted
     resource_upsertion_type: searchable_resource_upserted
-    service_instance_id: '1'
+    service_instance_id: 'rest.1'
     workers: 1
 
 shareProcessNamespace: false

--- a/charts/notification/Chart.yaml
+++ b/charts/notification/Chart.yaml
@@ -5,13 +5,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.2"
+appVersion: "1.0.0"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.

--- a/charts/notification/values.yaml
+++ b/charts/notification/values.yaml
@@ -33,6 +33,11 @@ parameters:
       </html>
     kafka_servers:
     - kafka:9092
+    kafka_security_protocol: PLAINTEXT
+    kafka_ssl_cafile: null
+    kafka_ssl_certfile: null
+    kafka_ssl_keyfile: null
+    kafka_ssl_password: null
     login_password: test
     login_user: test@test.com
     notification_event_topic: notifications
@@ -44,7 +49,7 @@ parameters:
 
       Warm regards,
       The GHGA Team
-    service_instance_id: 'ns_1'
+    service_instance_id: 'rest.1'
     service_name: ns
     smtp_host: 127.0.0.1
     smtp_port: 587

--- a/charts/test-oidc-provider/Chart.yaml
+++ b/charts/test-oidc-provider/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/test-oidc-provider/values.yaml
+++ b/charts/test-oidc-provider/values.yaml
@@ -54,4 +54,6 @@ parameters:
     valid_seconds: 3600
     workers: 1
 
+    service_instance_id: rest.1
+
 shareProcessNamespace: false

--- a/charts/well-known-value/Chart.yaml
+++ b/charts/well-known-value/Chart.yaml
@@ -5,13 +5,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.2"
+appVersion: "1.0.1"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.

--- a/charts/work-package/Chart.yaml
+++ b/charts/work-package/Chart.yaml
@@ -11,7 +11,7 @@ version: 1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.1"
+appVersion: "2.0.2"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.

--- a/charts/work-package/Chart.yaml
+++ b/charts/work-package/Chart.yaml
@@ -5,13 +5,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.4"
+appVersion: "2.0.1"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.

--- a/charts/work-package/values.yaml
+++ b/charts/work-package/values.yaml
@@ -37,7 +37,7 @@ mapping:
 
 parameters:
   default:
-    api_root_path: /
+    api_root_path: ""
     auth_algs:
     - ES256
     auth_check_claims:
@@ -45,6 +45,7 @@ parameters:
       exp: null
       iat: null
       name: null
+      id: null
     auth_key: '{}'
     auth_map_claims: {}
     auto_reload: true
@@ -62,6 +63,11 @@ parameters:
     download_access_url: http://claims-repository-svc:8080/download-access
     host: "0.0.0.0"
     kafka_servers: []
+    kafka_security_protocol: PLAINTEXT
+    kafka_ssl_cafile: null
+    kafka_ssl_certfile: null
+    kafka_ssl_keyfile: null
+    kafka_ssl_password: null
 
     openapi_url: /openapi.json
     port: 8080
@@ -72,8 +78,8 @@ parameters:
     work_packages_collection: workPackages
     workers: 1
   rest:
-    service_instance_id: 'wps_rest_1'
+    service_instance_id: 'rest.1'
   consumer:
-    service_instance_id: 'wps_consumer_1'
+    service_instance_id: 'consumer.1'
 
 shareProcessNamespace: false


### PR DESCRIPTION
This PR updates service versions and configurations as well as the chart versions to prepare Archive 1.0 release. Below I've listed the related service releases and configuration updates from Archive 0.9 to 1.0. Only the listed variables are changed, the rest may remain the same. If not listed, the services do not have any configuration updates.

The Data Portal UI is still under development, so not yet included here.

### General for all services
`service_instance_id` should be updated to
- `rest.1` for APIs 
- `consumer.1` for Consumers

### well-known-value-service
`0.1.2 -> 1.0.1`

### metldata
`0.4.5. -> 1.2.1`

Updates:
```
kafka_security_protocol: PLAINTEXT
kafka_ssl_cafile: null
kafka_ssl_certfile: null
kafka_ssl_keyfile: null
kafka_ssl_password: null
kafka_servers: []
```

### mass
`0.3.5 -> 1.0.1`

Updates:
```
kafka_security_protocol: PLAINTEXT
kafka_ssl_cafile: null
kafka_ssl_certfile: null
kafka_ssl_keyfile: null
kafka_ssl_password: null
kafka_servers: []
```

### encryption-key-store-service
`0.3.9 -> 1.0.1`

Updates:
```
vault_path: ekss
vault_kube_role: null
service_account_token_path: "/var/run/secrets/kubernetes.io/serviceaccount/token"
```
- **`vault_path`** _(string)_: Path without leading or trailing slashes where secrets should be stored in the vault.
- **`vault_kube_role`**: Vault role name used for Kubernetes authentication. Default: `null`
- **`service_account_token_path`** _(string, format: path)_: Path to service account token used by kube auth adapter. Default: `"/var/run/secrets/kubernetes.io/serviceaccount/token"`.

### download-controller-service
`0.6.4 -> 1.1.0`

Removed:
```
s3_access_key_id
s3_endpoint_url
s3_secret_access_key
s3_session_token
outbox_bucket
```

Updates:
```
kafka_security_protocol: PLAINTEXT
kafka_ssl_cafile: null
kafka_ssl_certfile: null
kafka_ssl_keyfile: null
kafka_ssl_password: null
kafka_servers: []
object_storages:
  test:
    bucket: outbox
    credentials:
      aws_config_ini: null
      s3_endpoint_url: null
      s3_access_key_id: null
      s3_secret_access_key: null
      s3_session_token: null
```

### internal-file-registry-service
`0.4.0 -> 1.1.0`

Removed:
```
s3_access_key_id
s3_endpoint_url
s3_secret_access_key
s3_session_token
permanent_bucket
```

Updates:
```
kafka_security_protocol: PLAINTEXT
kafka_ssl_cafile: null
kafka_ssl_certfile: null
kafka_ssl_keyfile: null
kafka_ssl_password: null
kafka_servers: []
object_storages:
  test:
    bucket: permanent
    credentials:
      aws_config_ini: null
      s3_endpoint_url: null
      s3_access_key_id: null
      s3_secret_access_key: null
      s3_session_token: null
```

### auth-service:
`0.5.6 -> 2.3.0`

Updates:
```
db_url -> db_connection_str

kafka_security_protocol: PLAINTEXT
kafka_ssl_cafile: null
kafka_ssl_certfile: null
kafka_ssl_keyfile: null
kafka_ssl_password: null
kafka_servers: []
dataset_deletion_event_topic: metadata_datasets
dataset_deletion_event_type: dataset_deleted
ivas_collection: ivas
user_tokens_collection: user_tokens
auth_check_claims:
	...
	id: null
```
**Auth Adapter**
```
totp_encryption_key: 4z8123...
```

- **`totp_encryption_key`**: Base64 encoded key used to encrypt TOTP secrets. Default: `null`.

### test-oidc-provider
`0.2.2 -> 1.1.1`

### work-package-service
`0.1.4 -> 2.0.2`

Updates:
```
kafka_security_protocol: PLAINTEXT
kafka_ssl_cafile: null
kafka_ssl_certfile: null
kafka_ssl_keyfile: null
kafka_ssl_password: null
kafka_servers: []
auth_check_claims:
  ...
  id: null
```

### access-request-service
`0.1.2 -> 2.0.1`

Removed:
```
notification_event_topic
notification_event_type
data_steward_email
```

Updates:
```
access_request_events_topic: access_request_events
access_request_created_event_type: access_request_created
access_request_allowed_event_type: access_request_allowed
access_request_denied_event_type: access_request_denied
kafka_security_protocol: PLAINTEXT
kafka_ssl_cafile: null
kafka_ssl_certfile: null
kafka_ssl_keyfile: null
kafka_ssl_password: null
kafka_servers: []
auth_check_claims:
  ...
  id: null
```

### file-ingest-service
`0.1.5 -> 1.1.1`

Updates:
```
kafka_security_protocol: PLAINTEXT
kafka_ssl_cafile: null
kafka_ssl_certfile: null
kafka_ssl_keyfile: null
kafka_ssl_password: null
kafka_servers: []
selected_storage_alias: staging
service_account_token_path: "/var/run/secrets/kubernetes.io/serviceaccount/token"
vault_path: ekss
vault_kube_role: ""
```

- **`selected_storage_alias`** _(string)_: S3 endpoint alias of the object storage node the bucket and object(s) corresponding to the upload metadata have been uploaded to. This should point to a node containing a staging bucket.
- **`service_account_token_path`** _(string, format: path)_: Path to service account token used by kube auth adapter. Default: `"/var/run/secrets/kubernetes.io/serviceaccount/token"`.

### notification-service
`0.1.2 -> 1.0.0`

Notification service is still work in progress and will be deployed together with a new service that orchestrates the notifications.

Updates:
```
kafka_security_protocol: PLAINTEXT
kafka_ssl_cafile: null
kafka_ssl_certfile: null
kafka_ssl_keyfile: null
kafka_ssl_password: null
kafka_servers: []
```