### PR TITLE
Upgrade EKSS service version

### DIFF
--- a/charts/encryption-key-store/Chart.yaml
+++ b/charts/encryption-key-store/Chart.yaml
@@ -5,13 +5,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.1"
+appVersion: "1.1.0"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.


### PR DESCRIPTION
The EKSS chart 1.0.0 contains configuration parameters from EKSS 1.1.0 but the service version was set to 1.0.1, so either the parameters or the service version needs to be upgraded. EKSS 1.1.0 version is also tested in Archive Test Bed so it should be okay to use the newer version.