### PR TITLE
Add generic templates for mounting secrets and volumes

### DIFF
--- a/charts/access-request/Chart.lock
+++ b/charts/access-request/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.2
-digest: sha256:76c50edca6cf6195fbcf6e1dc394e93f41e07952d003e5ba3edb0a97a288690e
-generated: "2024-03-05T13:32:18.777839Z"
+  version: 0.2.3
+digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
+generated: "2024-05-03T11:05:54.819015139+02:00"

--- a/charts/access-request/Chart.yaml
+++ b/charts/access-request/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.2
+  version: 0.2.3
   repository: file://../ghga-common

--- a/charts/access-request/templates/deployment.yml
+++ b/charts/access-request/templates/deployment.yml
@@ -63,6 +63,7 @@ spec:
           mountPath: "/home/appuser/.{{ .Values.config_prefix }}.yaml"
           subPath: .{{ .Values.config_prefix }}.yaml
           readOnly: true
+        {{- include "ghga-common.volume-mounts" . | nindent 8 }}
       volumes:
       - name: config
         configMap:
@@ -70,4 +71,5 @@ spec:
           items:
           - key: parameters
             path: .{{ .Values.config_prefix }}.yaml
+      {{- include "ghga-common.volumes" . | nindent 6 }}
       restartPolicy: Always

--- a/charts/access-request/values.yaml
+++ b/charts/access-request/values.yaml
@@ -79,3 +79,5 @@ parameters:
     workers: 1
 
 shareProcessNamespace: false
+kafkaSecrets:
+  enabled: true

--- a/charts/access-request/values.yaml
+++ b/charts/access-request/values.yaml
@@ -80,4 +80,4 @@ parameters:
 
 shareProcessNamespace: false
 kafkaSecrets:
-  enabled: true
+  enabled: false

--- a/charts/auth-service/Chart.lock
+++ b/charts/auth-service/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.2
-digest: sha256:76c50edca6cf6195fbcf6e1dc394e93f41e07952d003e5ba3edb0a97a288690e
-generated: "2024-03-05T13:32:18.777839Z"
+  version: 0.2.3
+digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
+generated: "2024-05-03T11:09:11.200235195+02:00"

--- a/charts/auth-service/Chart.yaml
+++ b/charts/auth-service/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.2
+  version: 0.2.3
   repository: file://../ghga-common

--- a/charts/auth-service/templates/deployment.yml
+++ b/charts/auth-service/templates/deployment.yml
@@ -63,6 +63,7 @@ spec:
           mountPath: "/home/appuser/.{{ .Values.config_prefix }}.yaml"
           subPath: .{{ .Values.config_prefix }}.yaml
           readOnly: true
+        {{- include "ghga-common.volume-mounts" . | nindent 8 }}
       volumes:
       - name: config
         configMap:
@@ -70,4 +71,5 @@ spec:
           items:
           - key: parameters
             path: .{{ .Values.config_prefix }}.yaml
+      {{- include "ghga-common.volumes" . | nindent 6 }}
       restartPolicy: Always

--- a/charts/auth-service/values.yaml
+++ b/charts/auth-service/values.yaml
@@ -106,3 +106,5 @@ authService:
     name: authentication
 
 shareProcessNamespace: false
+kafkaSecrets:
+  enabled: true

--- a/charts/auth-service/values.yaml
+++ b/charts/auth-service/values.yaml
@@ -107,4 +107,4 @@ authService:
 
 shareProcessNamespace: false
 kafkaSecrets:
-  enabled: true
+  enabled: false

--- a/charts/download-controller/Chart.lock
+++ b/charts/download-controller/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.2
-digest: sha256:76c50edca6cf6195fbcf6e1dc394e93f41e07952d003e5ba3edb0a97a288690e
-generated: "2024-03-05T13:32:18.777839Z"
+  version: 0.2.3
+digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
+generated: "2024-05-03T11:08:32.847175864+02:00"

--- a/charts/download-controller/Chart.yaml
+++ b/charts/download-controller/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.2
+  version: 0.2.3
   repository: file://../ghga-common

--- a/charts/download-controller/templates/deployment.yml
+++ b/charts/download-controller/templates/deployment.yml
@@ -88,6 +88,7 @@ spec:
           mountPath: "/home/appuser/.{{ .Values.config_prefix }}.yaml"
           subPath: .{{ .Values.config_prefix }}.yaml
           readOnly: true
+        {{- include "ghga-common.volume-mounts" . | nindent 8 }}
       volumes:
       - name: config-rest
         configMap:
@@ -101,4 +102,5 @@ spec:
           items:
           - key: parameters-consumer
             path: .{{ .Values.config_prefix }}.yaml
+      {{- include "ghga-common.volumes" . | nindent 6 }}
       restartPolicy: Always

--- a/charts/download-controller/values.yaml
+++ b/charts/download-controller/values.yaml
@@ -105,3 +105,5 @@ parameters:
     service_instance_id: 'consumer.1'
 
 shareProcessNamespace: false
+kafkaSecrets:
+  enabled: true

--- a/charts/download-controller/values.yaml
+++ b/charts/download-controller/values.yaml
@@ -106,4 +106,4 @@ parameters:
 
 shareProcessNamespace: false
 kafkaSecrets:
-  enabled: true
+  enabled: false

--- a/charts/encryption-key-store/Chart.lock
+++ b/charts/encryption-key-store/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.2
-digest: sha256:76c50edca6cf6195fbcf6e1dc394e93f41e07952d003e5ba3edb0a97a288690e
-generated: "2024-03-05T13:32:18.777839Z"
+  version: 0.2.3
+digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
+generated: "2024-05-03T09:25:34.42043311+02:00"

--- a/charts/encryption-key-store/Chart.yaml
+++ b/charts/encryption-key-store/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.2
+  version: 0.2.3
   repository: file://../ghga-common

--- a/charts/encryption-key-store/templates/deployment.yml
+++ b/charts/encryption-key-store/templates/deployment.yml
@@ -63,6 +63,7 @@ spec:
           mountPath: "/home/appuser/.{{ .Values.config_prefix }}.yaml"
           subPath: .{{ .Values.config_prefix }}.yaml
           readOnly: true
+        {{- include "ghga-common.volume-mounts" . | nindent 8 }}
       volumes:
       - name: config
         configMap:
@@ -70,4 +71,5 @@ spec:
           items:
           - key: parameters
             path: .{{ .Values.config_prefix }}.yaml
+      {{- include "ghga-common.volumes" . | nindent 6 }}
       restartPolicy: Always

--- a/charts/encryption-key-store/values.yaml
+++ b/charts/encryption-key-store/values.yaml
@@ -34,6 +34,7 @@ parameters:
     server_private_key: <Please fill>
     server_public_key: <Please fill>
     service_name: encryption_key_store
+    service_instance_id: test
     vault_url: http://vault:8200
     vault_verify: false
     vault_role_id: null
@@ -43,3 +44,5 @@ parameters:
     workers: 1
 
 shareProcessNamespace: false
+kafkaSecrets:
+  enabled: true

--- a/charts/encryption-key-store/values.yaml
+++ b/charts/encryption-key-store/values.yaml
@@ -45,4 +45,4 @@ parameters:
 
 shareProcessNamespace: false
 kafkaSecrets:
-  enabled: true
+  enabled: false

--- a/charts/file-ingest/Chart.lock
+++ b/charts/file-ingest/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.2
-digest: sha256:76c50edca6cf6195fbcf6e1dc394e93f41e07952d003e5ba3edb0a97a288690e
-generated: "2024-03-05T13:32:18.777839Z"
+  version: 0.2.3
+digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
+generated: "2024-05-03T11:07:18.963195793+02:00"

--- a/charts/file-ingest/Chart.yaml
+++ b/charts/file-ingest/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.2
+  version: 0.2.3
   repository: file://../ghga-common

--- a/charts/file-ingest/templates/deployment.yml
+++ b/charts/file-ingest/templates/deployment.yml
@@ -63,6 +63,7 @@ spec:
           mountPath: "/home/appuser/.{{ .Values.config_prefix }}.yaml"
           subPath: .{{ .Values.config_prefix }}.yaml
           readOnly: true
+        {{- include "ghga-common.volume-mounts" . | nindent 8 }}
       volumes:
       - name: config
         configMap:
@@ -70,4 +71,5 @@ spec:
           items:
           - key: parameters
             path: .{{ .Values.config_prefix }}.yaml
+      {{- include "ghga-common.volumes" . | nindent 6 }}
       restartPolicy: Always

--- a/charts/file-ingest/values.yaml
+++ b/charts/file-ingest/values.yaml
@@ -71,3 +71,5 @@ parameters:
     selected_storage_alias: staging
 
 shareProcessNamespace: false
+kafkaSecrets:
+  enabled: true

--- a/charts/file-ingest/values.yaml
+++ b/charts/file-ingest/values.yaml
@@ -72,4 +72,4 @@ parameters:
 
 shareProcessNamespace: false
 kafkaSecrets:
-  enabled: true
+  enabled: false

--- a/charts/ghga-common/Chart.yaml
+++ b/charts/ghga-common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ghga-common/templates/_kafka-secrets.tpl
+++ b/charts/ghga-common/templates/_kafka-secrets.tpl
@@ -1,0 +1,15 @@
+{{- define "ghga-common.kafka-secrets-volume" -}}
+{{- if .Values.kafkaSecrets.enabled -}}
+- name: kafka-secret
+  secret:
+    secretName: {{ required "A valid .Values.kafkaSecrets.name is required!" .Values.kafkaSecrets.name }}
+    optional: false
+{{- end -}}
+{{- end -}}
+{{- define "ghga-common.kafka-secrets-volume-mount" -}}
+{{- if .Values.kafkaSecrets.enabled -}}
+- mountPath: {{ .Values.kafkaSecrets.mountPath | default "/kafka-secrets/" }}
+  name: kafka-secret
+  readOnly: true
+{{- end -}}
+{{- end -}}

--- a/charts/ghga-common/templates/_volumes.tpl
+++ b/charts/ghga-common/templates/_volumes.tpl
@@ -1,0 +1,10 @@
+{{- define "ghga-common.volumes" -}}
+{{- if .Values.kafkaSecrets.enabled -}}
+{{- include "ghga-common.kafka-secrets-volume" . -}}
+{{- end -}}
+{{- end -}}
+{{- define "ghga-common.volume-mounts" -}}
+{{- if .Values.kafkaSecrets.enabled -}}
+{{- include "ghga-common.kafka-secrets-volume-mount" . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/ghga-common/templates/_volumes.tpl
+++ b/charts/ghga-common/templates/_volumes.tpl
@@ -1,10 +1,6 @@
 {{- define "ghga-common.volumes" -}}
-{{- if .Values.kafkaSecrets.enabled -}}
 {{- include "ghga-common.kafka-secrets-volume" . -}}
 {{- end -}}
-{{- end -}}
 {{- define "ghga-common.volume-mounts" -}}
-{{- if .Values.kafkaSecrets.enabled -}}
 {{- include "ghga-common.kafka-secrets-volume-mount" . -}}
-{{- end -}}
 {{- end -}}

--- a/charts/internal-file-registry/Chart.lock
+++ b/charts/internal-file-registry/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.2
-digest: sha256:76c50edca6cf6195fbcf6e1dc394e93f41e07952d003e5ba3edb0a97a288690e
-generated: "2024-03-05T13:32:18.777839Z"
+  version: 0.2.3
+digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
+generated: "2024-05-03T11:02:56.299473422+02:00"

--- a/charts/internal-file-registry/Chart.yaml
+++ b/charts/internal-file-registry/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.2
+  version: 0.2.3
   repository: file://../ghga-common

--- a/charts/internal-file-registry/templates/deployment.yml
+++ b/charts/internal-file-registry/templates/deployment.yml
@@ -51,6 +51,7 @@ spec:
           mountPath: "/home/appuser/.{{ .Values.config_prefix }}.yaml"
           subPath: .{{ .Values.config_prefix }}.yaml
           readOnly: true
+        {{- include "ghga-common.volume-mounts" . | nindent 8 }}
       volumes:
       - name: config
         configMap:
@@ -58,4 +59,5 @@ spec:
           items:
           - key: parameters
             path: .{{ .Values.config_prefix }}.yaml
+      {{- include "ghga-common.volumes" . | nindent 6 }}
       restartPolicy: Always

--- a/charts/internal-file-registry/values.yaml
+++ b/charts/internal-file-registry/values.yaml
@@ -53,4 +53,4 @@ parameters:
 
 shareProcessNamespace: false
 kafkaSecrets:
-  enabled: true
+  enabled: false

--- a/charts/internal-file-registry/values.yaml
+++ b/charts/internal-file-registry/values.yaml
@@ -52,3 +52,5 @@ parameters:
           s3_session_token: null
 
 shareProcessNamespace: false
+kafkaSecrets:
+  enabled: true

--- a/charts/mass/Chart.lock
+++ b/charts/mass/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.2
-digest: sha256:76c50edca6cf6195fbcf6e1dc394e93f41e07952d003e5ba3edb0a97a288690e
-generated: "2024-03-05T13:32:18.777839Z"
+  version: 0.2.3
+digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
+generated: "2024-05-03T11:06:30.874720703+02:00"

--- a/charts/mass/Chart.yaml
+++ b/charts/mass/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.2
+  version: 0.2.3
   repository: file://../ghga-common

--- a/charts/mass/templates/deployment.yml
+++ b/charts/mass/templates/deployment.yml
@@ -63,6 +63,7 @@ spec:
           mountPath: "/home/appuser/.{{ .Values.config_prefix }}.yaml"
           subPath: .{{ .Values.config_prefix }}.yaml
           readOnly: true
+        {{- include "ghga-common.volume-mounts" . | nindent 8 }}
       - image: "{{ .Values.image.name }}:{{ default .Chart.AppVersion .Values.image.tag }}"
         {{- include "ghga-common.command-args" (list "mass consume-events")  | nindent 8 }}
         name: {{ .Release.Name }}-consumer
@@ -88,6 +89,7 @@ spec:
           mountPath: "/home/appuser/.{{ .Values.config_prefix }}.yaml"
           subPath: .{{ .Values.config_prefix }}.yaml
           readOnly: true
+        {{- include "ghga-common.volume-mounts" . | nindent 8 }}
       volumes:
       - name: config-rest
         configMap:
@@ -101,4 +103,5 @@ spec:
           items:
           - key: parameters-consumer
             path: .{{ .Values.config_prefix }}.yaml
+      {{- include "ghga-common.volumes" . | nindent 6 }}
       restartPolicy: Always

--- a/charts/mass/values.yaml
+++ b/charts/mass/values.yaml
@@ -76,3 +76,5 @@ parameters:
     service_instance_id: 'consumer.1'
 
 shareProcessNamespace: false
+kafkaSecrets:
+  enabled: true

--- a/charts/mass/values.yaml
+++ b/charts/mass/values.yaml
@@ -77,4 +77,4 @@ parameters:
 
 shareProcessNamespace: false
 kafkaSecrets:
-  enabled: true
+  enabled: false

--- a/charts/metldata/Chart.lock
+++ b/charts/metldata/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.2
-digest: sha256:76c50edca6cf6195fbcf6e1dc394e93f41e07952d003e5ba3edb0a97a288690e
-generated: "2024-03-05T13:32:18.777839Z"
+  version: 0.2.3
+digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
+generated: "2024-05-03T11:10:13.707468684+02:00"

--- a/charts/metldata/Chart.yaml
+++ b/charts/metldata/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.2
+  version: 0.2.3
   repository: file://../ghga-common

--- a/charts/metldata/templates/deployment.yml
+++ b/charts/metldata/templates/deployment.yml
@@ -63,6 +63,7 @@ spec:
           mountPath: "/home/appuser/.{{ .Values.config_prefix }}.yaml"
           subPath: .{{ .Values.config_prefix }}.yaml
           readOnly: true
+        {{- include "ghga-common.volume-mounts" . | nindent 8 }}
       volumes:
       - name: config
         configMap:
@@ -70,4 +71,5 @@ spec:
           items:
           - key: parameters
             path: .{{ .Values.config_prefix }}.yaml
+      {{- include "ghga-common.volumes" . | nindent 6 }}
       restartPolicy: Always

--- a/charts/metldata/values.yaml
+++ b/charts/metldata/values.yaml
@@ -73,4 +73,4 @@ parameters:
 
 shareProcessNamespace: false
 kafkaSecrets:
-  enabled: true
+  enabled: false

--- a/charts/metldata/values.yaml
+++ b/charts/metldata/values.yaml
@@ -72,3 +72,5 @@ parameters:
     workers: 1
 
 shareProcessNamespace: false
+kafkaSecrets:
+  enabled: true

--- a/charts/notification/Chart.lock
+++ b/charts/notification/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.2
-digest: sha256:76c50edca6cf6195fbcf6e1dc394e93f41e07952d003e5ba3edb0a97a288690e
-generated: "2024-03-05T13:32:18.777839Z"
+  version: 0.2.3
+digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
+generated: "2024-05-03T11:12:51.893128991+02:00"

--- a/charts/notification/Chart.yaml
+++ b/charts/notification/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/notification/Chart.yaml
+++ b/charts/notification/Chart.yaml
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.2
+  version: 0.2.3
   repository: file://../ghga-common

--- a/charts/notification/templates/deployment.yml
+++ b/charts/notification/templates/deployment.yml
@@ -51,6 +51,7 @@ spec:
           mountPath: "/home/appuser/.{{ .Values.config_prefix }}.yaml"
           subPath: .{{ .Values.config_prefix }}.yaml
           readOnly: true
+        {{- include "ghga-common.volume-mounts" . | nindent 8 }}
       volumes:
       - name: config
         configMap:
@@ -58,4 +59,5 @@ spec:
           items:
           - key: parameters
             path: .{{ .Values.config_prefix }}.yaml
+      {{- include "ghga-common.volumes" . | nindent 6 }}
       restartPolicy: Always

--- a/charts/notification/values.yaml
+++ b/charts/notification/values.yaml
@@ -56,3 +56,5 @@ parameters:
     use_starttls: false
 
 shareProcessNamespace: false
+kafkaSecrets:
+  enabled: true

--- a/charts/notification/values.yaml
+++ b/charts/notification/values.yaml
@@ -57,4 +57,4 @@ parameters:
 
 shareProcessNamespace: false
 kafkaSecrets:
-  enabled: true
+  enabled: false

--- a/charts/test-oidc-provider/Chart.lock
+++ b/charts/test-oidc-provider/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.2
-digest: sha256:76c50edca6cf6195fbcf6e1dc394e93f41e07952d003e5ba3edb0a97a288690e
-generated: "2024-03-05T13:32:18.777839Z"
+  version: 0.2.3
+digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
+generated: "2024-05-03T11:10:34.544136566+02:00"

--- a/charts/test-oidc-provider/Chart.yaml
+++ b/charts/test-oidc-provider/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.2
+  version: 0.2.3
   repository: file://../ghga-common

--- a/charts/test-oidc-provider/templates/deployment.yml
+++ b/charts/test-oidc-provider/templates/deployment.yml
@@ -63,6 +63,7 @@ spec:
           mountPath: "/home/appuser/.{{ .Values.config_prefix }}.yaml"
           subPath: .{{ .Values.config_prefix }}.yaml
           readOnly: true
+        {{- include "ghga-common.volume-mounts" . | nindent 8 }}
       volumes:
       - name: config
         configMap:
@@ -70,4 +71,5 @@ spec:
           items:
           - key: parameters
             path: .{{ .Values.config_prefix }}.yaml
+      {{- include "ghga-common.volumes" . | nindent 6 }}
       restartPolicy: Always

--- a/charts/test-oidc-provider/values.yaml
+++ b/charts/test-oidc-provider/values.yaml
@@ -57,3 +57,5 @@ parameters:
     service_instance_id: rest.1
 
 shareProcessNamespace: false
+kafkaSecrets:
+  enabled: true

--- a/charts/test-oidc-provider/values.yaml
+++ b/charts/test-oidc-provider/values.yaml
@@ -58,4 +58,4 @@ parameters:
 
 shareProcessNamespace: false
 kafkaSecrets:
-  enabled: true
+  enabled: false

--- a/charts/well-known-value/Chart.lock
+++ b/charts/well-known-value/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.2
-digest: sha256:76c50edca6cf6195fbcf6e1dc394e93f41e07952d003e5ba3edb0a97a288690e
-generated: "2024-03-05T13:32:18.777839Z"
+  version: 0.2.3
+digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
+generated: "2024-05-03T11:08:15.749186052+02:00"

--- a/charts/well-known-value/Chart.yaml
+++ b/charts/well-known-value/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.2
+  version: 0.2.3
   repository: file://../ghga-common

--- a/charts/well-known-value/templates/deployment.yml
+++ b/charts/well-known-value/templates/deployment.yml
@@ -63,6 +63,7 @@ spec:
           mountPath: "/home/appuser/.{{ .Values.config_prefix }}.yaml"
           subPath: .{{ .Values.config_prefix }}.yaml
           readOnly: true
+        {{- include "ghga-common.volume-mounts" . | nindent 8 }}
       volumes:
       - name: config
         configMap:
@@ -70,4 +71,5 @@ spec:
           items:
           - key: parameters
             path: .{{ .Values.config_prefix }}.yaml
+      {{- include "ghga-common.volumes" . | nindent 6 }}
       restartPolicy: Always

--- a/charts/well-known-value/values.yaml
+++ b/charts/well-known-value/values.yaml
@@ -56,3 +56,5 @@ parameters:
     wps_api_url: http://127.0.0.1
 
 shareProcessNamespace: false
+kafkaSecrets:
+  enabled: true

--- a/charts/well-known-value/values.yaml
+++ b/charts/well-known-value/values.yaml
@@ -57,4 +57,4 @@ parameters:
 
 shareProcessNamespace: false
 kafkaSecrets:
-  enabled: true
+  enabled: false

--- a/charts/work-package/Chart.lock
+++ b/charts/work-package/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.2
-digest: sha256:76c50edca6cf6195fbcf6e1dc394e93f41e07952d003e5ba3edb0a97a288690e
-generated: "2024-03-05T13:32:18.777839Z"
+  version: 0.2.3
+digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
+generated: "2024-05-03T11:11:22.69164893+02:00"

--- a/charts/work-package/Chart.yaml
+++ b/charts/work-package/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.2
+  version: 0.2.3
   repository: file://../ghga-common

--- a/charts/work-package/templates/deployment.yml
+++ b/charts/work-package/templates/deployment.yml
@@ -63,6 +63,7 @@ spec:
           mountPath: "/home/appuser/.{{ .Values.config_prefix }}.yaml"
           subPath: .{{ .Values.config_prefix }}.yaml
           readOnly: true
+        {{- include "ghga-common.volume-mounts" . | nindent 8 }}
       - image: "{{ .Values.image.name }}:{{ default .Chart.AppVersion .Values.image.tag }}"
         {{- include "ghga-common.command-args" (list "wps consume-events")  | nindent 8 }}
         name: {{ .Release.Name }}-consumer
@@ -88,6 +89,7 @@ spec:
           mountPath: "/home/appuser/.{{ .Values.config_prefix }}.yaml"
           subPath: .{{ .Values.config_prefix }}.yaml
           readOnly: true
+        {{- include "ghga-common.volume-mounts" . | nindent 8 }}
       volumes:
       - name: config-rest
         configMap:
@@ -101,4 +103,5 @@ spec:
           items:
           - key: parameters-consumer
             path: .{{ .Values.config_prefix }}.yaml
+      {{- include "ghga-common.volumes" . | nindent 6 }}
       restartPolicy: Always

--- a/charts/work-package/values.yaml
+++ b/charts/work-package/values.yaml
@@ -83,3 +83,5 @@ parameters:
     service_instance_id: 'consumer.1'
 
 shareProcessNamespace: false
+kafkaSecrets:
+  enabled: true

--- a/charts/work-package/values.yaml
+++ b/charts/work-package/values.yaml
@@ -84,4 +84,4 @@ parameters:
 
 shareProcessNamespace: false
 kafkaSecrets:
-  enabled: true
+  enabled: false


### PR DESCRIPTION
## Objective

- Add generic templates for Pod volume mounts. 
- Add templates to mount secrets (mainly certificates) generated by CRD `KafkaUser`