### PR TITLE
Add template for pod labels

### DIFF
--- a/charts/access-request/Chart.lock
+++ b/charts/access-request/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.3
-digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
-generated: "2024-05-03T11:05:54.819015139+02:00"
+  version: 0.2.5
+digest: sha256:c3391513804971830038033bb9c502b1f307e11e440ff8adbb3002f93e45dffe
+generated: "2024-06-10T11:58:40.550540673+02:00"

--- a/charts/access-request/Chart.yaml
+++ b/charts/access-request/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/access-request/Chart.yaml
+++ b/charts/access-request/Chart.yaml
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.3
+  version: 0.2.5
   repository: file://../ghga-common

--- a/charts/access-request/templates/deployment.yml
+++ b/charts/access-request/templates/deployment.yml
@@ -21,7 +21,7 @@ spec:
       labels:
         app: {{ .Release.Name }}
         version: staging
-        sidecar.istio.io/inject: "true"
+        {{- include "ghga-common.pod-extra-labels" .  | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}
       shareProcessNamespace: {{ .Values.shareProcessNamespace }}

--- a/charts/access-request/values.yaml
+++ b/charts/access-request/values.yaml
@@ -81,3 +81,7 @@ parameters:
 shareProcessNamespace: false
 kafkaSecrets:
   enabled: false
+
+# Add extra labels to the service pod
+# podExtraLabels:
+#   my-label: my-value

--- a/charts/auth-service/Chart.lock
+++ b/charts/auth-service/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.4
-digest: sha256:99150ef14cd2c7c963da63db7fc83f4737910c1d9975953010d0a469b0d22faa
-generated: "2024-06-04T15:08:18.720852+02:00"
+  version: 0.2.5
+digest: sha256:c3391513804971830038033bb9c502b1f307e11e440ff8adbb3002f93e45dffe
+generated: "2024-06-10T11:59:43.752895502+02:00"

--- a/charts/auth-service/Chart.yaml
+++ b/charts/auth-service/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/auth-service/Chart.yaml
+++ b/charts/auth-service/Chart.yaml
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.4
+  version: 0.2.5
   repository: file://../ghga-common

--- a/charts/auth-service/templates/deployment.yml
+++ b/charts/auth-service/templates/deployment.yml
@@ -21,7 +21,7 @@ spec:
       labels:
         app: {{ .Release.Name }}
         version: staging
-        sidecar.istio.io/inject: "true"
+        {{- include "ghga-common.pod-extra-labels" .  | nindent 8 }}
     spec:
       {{- include "ghga-common.image-pull-secrets" .  | nindent 6 }}
       serviceAccountName: {{ .Release.Name }}

--- a/charts/auth-service/values.yaml
+++ b/charts/auth-service/values.yaml
@@ -143,3 +143,6 @@ kafkaSecrets:
 # imagePullSecretNames:
 #  - name: dockerhub
 imagePullSecretNames: []
+
+podExtraLabels:
+  test: test-label

--- a/charts/auth-service/values.yaml
+++ b/charts/auth-service/values.yaml
@@ -144,5 +144,6 @@ kafkaSecrets:
 #  - name: dockerhub
 imagePullSecretNames: []
 
-podExtraLabels:
-  test: test-label
+# Add extra labels to the service pod
+# podExtraLabels:
+#   my-label: my-value

--- a/charts/data-portal-ui/Chart.lock
+++ b/charts/data-portal-ui/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.3
-digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
-generated: "2024-05-03T11:09:11.200235195+02:00"
+  version: 0.2.5
+digest: sha256:c3391513804971830038033bb9c502b1f307e11e440ff8adbb3002f93e45dffe
+generated: "2024-06-10T11:58:23.735820795+02:00"

--- a/charts/data-portal-ui/Chart.yaml
+++ b/charts/data-portal-ui/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/data-portal-ui/Chart.yaml
+++ b/charts/data-portal-ui/Chart.yaml
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.3
+  version: 0.2.5
   repository: file://../ghga-common

--- a/charts/data-portal-ui/templates/deployment.yml
+++ b/charts/data-portal-ui/templates/deployment.yml
@@ -20,8 +20,7 @@ spec:
         {{- end }}
       labels:
         app: {{ .Release.Name }}
-        sidecar.istio.io/inject: "true"
-        version: staging
+        {{- include "ghga-common.pod-extra-labels" .  | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}
       shareProcessNamespace: {{ .Values.shareProcessNamespace }}

--- a/charts/data-portal-ui/values.yaml
+++ b/charts/data-portal-ui/values.yaml
@@ -53,3 +53,7 @@ parameters:
     oidc_use_discovery: false
 
 shareProcessNamespace: false
+
+# Add extra labels to the service pod
+# podExtraLabels:
+#   my-label: my-value

--- a/charts/download-controller/Chart.lock
+++ b/charts/download-controller/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.3
-digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
-generated: "2024-05-03T11:08:32.847175864+02:00"
+  version: 0.2.5
+digest: sha256:c3391513804971830038033bb9c502b1f307e11e440ff8adbb3002f93e45dffe
+generated: "2024-06-10T11:59:31.740513513+02:00"

--- a/charts/download-controller/Chart.yaml
+++ b/charts/download-controller/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/download-controller/Chart.yaml
+++ b/charts/download-controller/Chart.yaml
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.3
+  version: 0.2.5
   repository: file://../ghga-common

--- a/charts/download-controller/templates/deployment.yml
+++ b/charts/download-controller/templates/deployment.yml
@@ -20,8 +20,7 @@ spec:
         {{- end }}
       labels:
         app: {{ .Release.Name }}
-        version: staging
-        sidecar.istio.io/inject: "true"
+        {{- include "ghga-common.pod-extra-labels" .  | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}
       shareProcessNamespace: {{ .Values.shareProcessNamespace }}

--- a/charts/download-controller/values.yaml
+++ b/charts/download-controller/values.yaml
@@ -107,3 +107,7 @@ parameters:
 shareProcessNamespace: false
 kafkaSecrets:
   enabled: false
+
+# Add extra labels to the service pod
+# podExtraLabels:
+#   my-label: my-value

--- a/charts/encryption-key-store/Chart.lock
+++ b/charts/encryption-key-store/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.3
-digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
-generated: "2024-05-03T09:25:34.42043311+02:00"
+  version: 0.2.5
+digest: sha256:c3391513804971830038033bb9c502b1f307e11e440ff8adbb3002f93e45dffe
+generated: "2024-06-10T11:58:31.971362847+02:00"

--- a/charts/encryption-key-store/Chart.yaml
+++ b/charts/encryption-key-store/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/encryption-key-store/Chart.yaml
+++ b/charts/encryption-key-store/Chart.yaml
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.3
+  version: 0.2.5
   repository: file://../ghga-common

--- a/charts/encryption-key-store/templates/deployment.yml
+++ b/charts/encryption-key-store/templates/deployment.yml
@@ -20,8 +20,7 @@ spec:
         {{- end }}
       labels:
         app: {{ .Release.Name }}
-        version: staging
-        sidecar.istio.io/inject: "true"
+        {{- include "ghga-common.pod-extra-labels" .  | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}
       shareProcessNamespace: {{ .Values.shareProcessNamespace }}

--- a/charts/encryption-key-store/values.yaml
+++ b/charts/encryption-key-store/values.yaml
@@ -46,3 +46,7 @@ parameters:
 shareProcessNamespace: false
 kafkaSecrets:
   enabled: false
+
+# Add extra labels to the service pod
+# podExtraLabels:
+#   my-label: my-value

--- a/charts/file-ingest/Chart.lock
+++ b/charts/file-ingest/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.3
-digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
-generated: "2024-05-03T11:07:18.963195793+02:00"
+  version: 0.2.5
+digest: sha256:c3391513804971830038033bb9c502b1f307e11e440ff8adbb3002f93e45dffe
+generated: "2024-06-10T11:58:57.33169417+02:00"

--- a/charts/file-ingest/Chart.yaml
+++ b/charts/file-ingest/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/file-ingest/Chart.yaml
+++ b/charts/file-ingest/Chart.yaml
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.3
+  version: 0.2.5
   repository: file://../ghga-common

--- a/charts/file-ingest/templates/deployment.yml
+++ b/charts/file-ingest/templates/deployment.yml
@@ -20,8 +20,7 @@ spec:
         {{- end }}
       labels:
         app: {{ .Release.Name }}
-        version: staging
-        sidecar.istio.io/inject: "true"
+        {{- include "ghga-common.pod-extra-labels" .  | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}
       shareProcessNamespace: {{ .Values.shareProcessNamespace }}

--- a/charts/file-ingest/values.yaml
+++ b/charts/file-ingest/values.yaml
@@ -73,3 +73,7 @@ parameters:
 shareProcessNamespace: false
 kafkaSecrets:
   enabled: false
+
+# Add extra labels to the service pod
+# podExtraLabels:
+#   my-label: my-value

--- a/charts/ghga-common/Chart.yaml
+++ b/charts/ghga-common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ghga-common/templates/_pod-extra-labels.tpl
+++ b/charts/ghga-common/templates/_pod-extra-labels.tpl
@@ -1,0 +1,5 @@
+{{- define "ghga-common.pod-extra-labels" -}}
+{{- if .Values.podExtraLabels -}}
+{{- toYaml .Values.podExtraLabels -}}
+{{- end -}}
+{{- end -}}

--- a/charts/internal-file-registry/Chart.lock
+++ b/charts/internal-file-registry/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.3
-digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
-generated: "2024-05-03T11:02:56.299473422+02:00"
+  version: 0.2.5
+digest: sha256:c3391513804971830038033bb9c502b1f307e11e440ff8adbb3002f93e45dffe
+generated: "2024-06-10T11:58:15.785072904+02:00"

--- a/charts/internal-file-registry/Chart.yaml
+++ b/charts/internal-file-registry/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/internal-file-registry/Chart.yaml
+++ b/charts/internal-file-registry/Chart.yaml
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.3
+  version: 0.2.5
   repository: file://../ghga-common

--- a/charts/internal-file-registry/templates/deployment.yml
+++ b/charts/internal-file-registry/templates/deployment.yml
@@ -20,8 +20,7 @@ spec:
         {{- end }}
       labels:
         app: {{ .Release.Name }}
-        version: staging
-        sidecar.istio.io/inject: "true"
+        {{- include "ghga-common.pod-extra-labels" .  | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}
       shareProcessNamespace: {{ .Values.shareProcessNamespace }}

--- a/charts/internal-file-registry/values.yaml
+++ b/charts/internal-file-registry/values.yaml
@@ -54,3 +54,7 @@ parameters:
 shareProcessNamespace: false
 kafkaSecrets:
   enabled: false
+
+# Add extra labels to the service pod
+# podExtraLabels:
+#   my-label: my-value

--- a/charts/mass/Chart.lock
+++ b/charts/mass/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.3
-digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
-generated: "2024-05-03T11:06:30.874720703+02:00"
+  version: 0.2.5
+digest: sha256:c3391513804971830038033bb9c502b1f307e11e440ff8adbb3002f93e45dffe
+generated: "2024-06-10T11:58:48.824605815+02:00"

--- a/charts/mass/Chart.yaml
+++ b/charts/mass/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mass/Chart.yaml
+++ b/charts/mass/Chart.yaml
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.3
+  version: 0.2.5
   repository: file://../ghga-common

--- a/charts/mass/templates/deployment.yml
+++ b/charts/mass/templates/deployment.yml
@@ -20,8 +20,7 @@ spec:
         {{- end }}
       labels:
         app: {{ .Release.Name }}
-        version: staging
-        sidecar.istio.io/inject: "true"
+        {{- include "ghga-common.pod-extra-labels" .  | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}
       shareProcessNamespace: {{ .Values.shareProcessNamespace }}

--- a/charts/mass/values.yaml
+++ b/charts/mass/values.yaml
@@ -78,3 +78,7 @@ parameters:
 shareProcessNamespace: false
 kafkaSecrets:
   enabled: false
+
+# Add extra labels to the service pod
+# podExtraLabels:
+#   my-label: my-value

--- a/charts/metldata/Chart.lock
+++ b/charts/metldata/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.3
-digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
-generated: "2024-05-03T11:10:13.707468684+02:00"
+  version: 0.2.5
+digest: sha256:c3391513804971830038033bb9c502b1f307e11e440ff8adbb3002f93e45dffe
+generated: "2024-06-10T12:02:09.138670016+02:00"

--- a/charts/metldata/Chart.yaml
+++ b/charts/metldata/Chart.yaml
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.3
+  version: 0.2.5
   repository: file://../ghga-common

--- a/charts/metldata/Chart.yaml
+++ b/charts/metldata/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/metldata/templates/deployment.yml
+++ b/charts/metldata/templates/deployment.yml
@@ -20,8 +20,7 @@ spec:
         {{- end }}
       labels:
         app: {{ .Release.Name }}
-        version: staging
-        sidecar.istio.io/inject: "true"
+        {{- include "ghga-common.pod-extra-labels" .  | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}
       shareProcessNamespace: {{ .Values.shareProcessNamespace }}

--- a/charts/metldata/values.yaml
+++ b/charts/metldata/values.yaml
@@ -74,3 +74,7 @@ parameters:
 shareProcessNamespace: false
 kafkaSecrets:
   enabled: false
+
+# Add extra labels to the service pod
+# podExtraLabels:
+#   my-label: my-value

--- a/charts/notification-orchestration/Chart.lock
+++ b/charts/notification-orchestration/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.3
-digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
-generated: "2024-05-03T11:12:51.893128991+02:00"
+  version: 0.2.5
+digest: sha256:c3391513804971830038033bb9c502b1f307e11e440ff8adbb3002f93e45dffe
+generated: "2024-06-10T11:59:06.59519106+02:00"

--- a/charts/notification-orchestration/Chart.yaml
+++ b/charts/notification-orchestration/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/notification-orchestration/Chart.yaml
+++ b/charts/notification-orchestration/Chart.yaml
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.3
+  version: 0.2.5
   repository: file://../ghga-common

--- a/charts/notification-orchestration/templates/deployment.yml
+++ b/charts/notification-orchestration/templates/deployment.yml
@@ -6,6 +6,7 @@ metadata:
     configmap-hash: {{ include (print $.Template.BasePath "/configmap.yml") . | sha256sum }}
   labels:
     app: {{ .Release.Name }}
+    {{- include "ghga-common.pod-extra-labels" .  | nindent 8 }}
 spec:
   revisionHistoryLimit: 1
   selector:

--- a/charts/notification-orchestration/values.yaml
+++ b/charts/notification-orchestration/values.yaml
@@ -47,3 +47,7 @@ parameters:
 shareProcessNamespace: false
 kafkaSecrets:
   enabled: false
+
+# Add extra labels to the service pod
+# podExtraLabels:
+#   my-label: my-value

--- a/charts/notification/Chart.lock
+++ b/charts/notification/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.3
-digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
-generated: "2024-05-03T11:12:51.893128991+02:00"
+  version: 0.2.5
+digest: sha256:c3391513804971830038033bb9c502b1f307e11e440ff8adbb3002f93e45dffe
+generated: "2024-06-10T11:59:14.93024573+02:00"

--- a/charts/notification/Chart.yaml
+++ b/charts/notification/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/notification/Chart.yaml
+++ b/charts/notification/Chart.yaml
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.3
+  version: 0.2.5
   repository: file://../ghga-common

--- a/charts/notification/templates/deployment.yml
+++ b/charts/notification/templates/deployment.yml
@@ -20,8 +20,7 @@ spec:
         {{- end }}
       labels:
         app: {{ .Release.Name }}
-        version: staging
-        sidecar.istio.io/inject: "true"
+        {{- include "ghga-common.pod-extra-labels" .  | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}
       shareProcessNamespace: {{ .Values.shareProcessNamespace }}

--- a/charts/notification/values.yaml
+++ b/charts/notification/values.yaml
@@ -58,3 +58,7 @@ parameters:
 shareProcessNamespace: false
 kafkaSecrets:
   enabled: false
+
+# Add extra labels to the service pod
+# podExtraLabels:
+#   my-label: my-value

--- a/charts/test-oidc-provider/Chart.lock
+++ b/charts/test-oidc-provider/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.3
-digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
-generated: "2024-05-03T11:10:34.544136566+02:00"
+  version: 0.2.5
+digest: sha256:c3391513804971830038033bb9c502b1f307e11e440ff8adbb3002f93e45dffe
+generated: "2024-06-10T12:00:03.145032754+02:00"

--- a/charts/test-oidc-provider/Chart.yaml
+++ b/charts/test-oidc-provider/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/test-oidc-provider/Chart.yaml
+++ b/charts/test-oidc-provider/Chart.yaml
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.3
+  version: 0.2.5
   repository: file://../ghga-common

--- a/charts/test-oidc-provider/templates/deployment.yml
+++ b/charts/test-oidc-provider/templates/deployment.yml
@@ -20,8 +20,7 @@ spec:
         {{- end }}
       labels:
         app: {{ .Release.Name }}
-        version: staging
-        sidecar.istio.io/inject: "true"
+        {{- include "ghga-common.pod-extra-labels" .  | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}
       shareProcessNamespace: {{ .Values.shareProcessNamespace }}

--- a/charts/test-oidc-provider/values.yaml
+++ b/charts/test-oidc-provider/values.yaml
@@ -59,3 +59,7 @@ parameters:
 shareProcessNamespace: false
 kafkaSecrets:
   enabled: false
+
+# Add extra labels to the service pod
+# podExtraLabels:
+#   my-label: my-value

--- a/charts/well-known-value/Chart.lock
+++ b/charts/well-known-value/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.3
-digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
-generated: "2024-05-03T11:08:15.749186052+02:00"
+  version: 0.2.5
+digest: sha256:c3391513804971830038033bb9c502b1f307e11e440ff8adbb3002f93e45dffe
+generated: "2024-06-10T11:59:23.277159291+02:00"

--- a/charts/well-known-value/Chart.yaml
+++ b/charts/well-known-value/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/well-known-value/Chart.yaml
+++ b/charts/well-known-value/Chart.yaml
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.3
+  version: 0.2.5
   repository: file://../ghga-common

--- a/charts/well-known-value/templates/deployment.yml
+++ b/charts/well-known-value/templates/deployment.yml
@@ -20,8 +20,7 @@ spec:
         {{- end }}
       labels:
         app: {{ .Release.Name }}
-        version: staging
-        sidecar.istio.io/inject: "true"
+        {{- include "ghga-common.pod-extra-labels" .  | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}
       shareProcessNamespace: {{ .Values.shareProcessNamespace }}

--- a/charts/well-known-value/values.yaml
+++ b/charts/well-known-value/values.yaml
@@ -58,3 +58,7 @@ parameters:
 shareProcessNamespace: false
 kafkaSecrets:
   enabled: false
+
+# Add extra labels to the service pod
+# podExtraLabels:
+#   my-label: my-value

--- a/charts/work-package/Chart.lock
+++ b/charts/work-package/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.3
-digest: sha256:c85429344c4acfa65f3233264521f5cecd87da1d4c5c1cac03e70e9f023a1b10
-generated: "2024-05-03T11:11:22.69164893+02:00"
+  version: 0.2.5
+digest: sha256:c3391513804971830038033bb9c502b1f307e11e440ff8adbb3002f93e45dffe
+generated: "2024-06-10T12:00:17.804634432+02:00"

--- a/charts/work-package/Chart.yaml
+++ b/charts/work-package/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/work-package/Chart.yaml
+++ b/charts/work-package/Chart.yaml
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.3
+  version: 0.2.5
   repository: file://../ghga-common

--- a/charts/work-package/templates/deployment.yml
+++ b/charts/work-package/templates/deployment.yml
@@ -20,8 +20,7 @@ spec:
         {{- end }}
       labels:
         app: {{ .Release.Name }}
-        version: staging
-        sidecar.istio.io/inject: "true"
+        {{- include "ghga-common.pod-extra-labels" .  | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}
       shareProcessNamespace: {{ .Values.shareProcessNamespace }}

--- a/charts/work-package/values.yaml
+++ b/charts/work-package/values.yaml
@@ -85,3 +85,7 @@ parameters:
 shareProcessNamespace: false
 kafkaSecrets:
   enabled: false
+
+# Add extra labels to the service pod
+# podExtraLabels:
+#   my-label: my-value


### PR DESCRIPTION
## Objective

This PR add template to dynamically set labels on pods. Currently labels such as istio's sidecar injection are hard coded in the chart. However, this should be more fine grade configurable.

## Tests

### Template rendering

```
helm template test charts/auth-service --set-json 'podExtraLabels={"label-test-0": "test", "label-test-1": "test"}'
# Source: auth-service/templates/deployment.yml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test
  annotations:
    configmap-hash: 0ff9ad82c50581dbe5f7ae141aea4b6e077dcb8fe9e14446bfabeff8ba23a076
  labels:
    app: test
spec:
  revisionHistoryLimit: 1
  selector:
    matchLabels:
      app: test
  template:
    metadata:
      annotations:
        configmap-hash: 0ff9ad82c50581dbe5f7ae141aea4b6e077dcb8fe9e14446bfabeff8ba23a076
      labels:
        app: test
        version: staging
        label-test-0: test
        label-test-1: test
    spec:
```

### Integration

```
helm install label-test charts/auth-service --set-json 'podExtraLabels={"label-test-0": "test", "label-test-1": "test"}' ;  
kubectl get pods --selector=label-test-0=test --selector=label-test-1=test
NAME: label-test
LAST DEPLOYED: Mon Jun 10 12:11:02 2024
NAMESPACE: test-0
STATUS: deployed
REVISION: 1
TEST SUITE: None
NAME                         READY   STATUS    RESTARTS   AGE
label-test-b976c5774-jwkjd   0/1     Pending   0          0s
```