### PR TITLE
Fix image pull secret templating

### DIFF
--- a/charts/auth-service/Chart.lock
+++ b/charts/auth-service/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.5
-digest: sha256:c3391513804971830038033bb9c502b1f307e11e440ff8adbb3002f93e45dffe
-generated: "2024-06-10T11:59:43.752895502+02:00"
+  version: 0.2.6
+digest: sha256:a8e3437e06ef82a2dd013ab7ad36bba30e2b1d7191bef57c3cc5244cef244502
+generated: "2024-06-10T14:50:31.821202+02:00"

--- a/charts/auth-service/Chart.yaml
+++ b/charts/auth-service/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.4
+  version: 0.2.5
   repository: file://../ghga-common

--- a/charts/auth-service/Chart.yaml
+++ b/charts/auth-service/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.5
+  version: 0.2.6
   repository: file://../ghga-common

--- a/charts/auth-service/templates/deployment.yml
+++ b/charts/auth-service/templates/deployment.yml
@@ -21,7 +21,9 @@ spec:
       labels:
         app: {{ .Release.Name }}
         version: staging
+        {{- if .Values.podExtraLabels }}
         {{- include "ghga-common.pod-extra-labels" .  | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ .Release.Name }}
       shareProcessNamespace: {{ .Values.shareProcessNamespace }}

--- a/charts/auth-service/templates/deployment.yml
+++ b/charts/auth-service/templates/deployment.yml
@@ -23,9 +23,11 @@ spec:
         version: staging
         sidecar.istio.io/inject: "true"
     spec:
-      {{- include "ghga-common.image-pull-secrets" .  | nindent 6 }}
       serviceAccountName: {{ .Release.Name }}
       shareProcessNamespace: {{ .Values.shareProcessNamespace }}
+      {{- if .Values.imagePullSecretNames }}
+      {{- include "ghga-common.image-pull-secrets" .  | nindent 6 }}
+      {{- end }}
       containers:
       - image: "{{ .Values.image.name }}:{{ default .Chart.AppVersion .Values.image.tag }}"
         {{- include "ghga-common.command-args" (list "auth-service")  | nindent 8 }}

--- a/charts/auth-service/values.yaml
+++ b/charts/auth-service/values.yaml
@@ -142,4 +142,5 @@ kafkaSecrets:
 # Used to add image pull secrets to deployment
 # imagePullSecretNames:
 #  - name: dockerhub
+#  - name: ex
 imagePullSecretNames: []

--- a/charts/ghga-common/Chart.yaml
+++ b/charts/ghga-common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ghga-common/Chart.yaml
+++ b/charts/ghga-common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ghga-common/templates/_image-pull-secrets.tpl
+++ b/charts/ghga-common/templates/_image-pull-secrets.tpl
@@ -2,5 +2,5 @@
 {{- if .Values.imagePullSecretNames -}}
 imagePullSecrets:
   {{- toYaml .Values.imagePullSecretNames | nindent 2 }}
-{{- end }}
+{{- end -}}
 {{- end -}}

--- a/charts/ghga-common/templates/_image-pull-secrets.tpl
+++ b/charts/ghga-common/templates/_image-pull-secrets.tpl
@@ -1,6 +1,6 @@
 {{- define "ghga-common.image-pull-secrets" -}}
 {{- if .Values.imagePullSecretNames -}}
 imagePullSecrets:
-  {{ toYaml .Values.imagePullSecretNames }}
-{{- end -}}
+  {{- toYaml .Values.imagePullSecretNames | nindent 2 }}
+{{- end }}
 {{- end -}}


### PR DESCRIPTION
Template rendering:

```shell
helm dep up ./auth-service

helm template test auth-service --set-json 'imagePullSecretNames=[{"name":"dockerhub"},{"name":"afro"}]' --set-json 'podExtraLabels={"label-test-0": "test", "label-test-1": "test"}'

# Source: auth-service/templates/deployment.yml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test
  annotations:
    configmap-hash: 0ff9ad82c50581dbe5f7ae141aea4b6e077dcb8fe9e14446bfabeff8ba23a076
  labels:
    app: test
spec:
  revisionHistoryLimit: 1
  selector:
    matchLabels:
      app: test
  template:
    metadata:
      annotations:
        configmap-hash: 0ff9ad82c50581dbe5f7ae141aea4b6e077dcb8fe9e14446bfabeff8ba23a076
      labels:
        app: test
        version: staging
        label-test-0: test
        label-test-1: test
    spec:
      serviceAccountName: test
      shareProcessNamespace: false
      imagePullSecrets:
        - name: dockerhub
        - name: afro
      containers:
      - image: "ghga/auth-service:2.4.2"
        command: ["sh", "-c"]
``` 



