### PR TITLE
Update test-oidc-provider to 1.2.0

### DIFF
--- a/charts/test-oidc-provider/Chart.yaml
+++ b/charts/test-oidc-provider/Chart.yaml
@@ -5,13 +5,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.1.2"
+appVersion: "1.2.0"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.

--- a/charts/test-oidc-provider/values.yaml
+++ b/charts/test-oidc-provider/values.yaml
@@ -49,7 +49,7 @@ parameters:
     openapi_url: /openapi.json
     port: 8080
     service_name: top
-    service_url: http://localhost:8080
+
     user_domain: home.org
     valid_seconds: 3600
     workers: 1


### PR DESCRIPTION
This new version doesn't require the `service_url` setting anymore.