### PR TITLE
Override entrypoint cmd

### DIFF
--- a/charts/access-request/Chart.lock
+++ b/charts/access-request/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.7
-digest: sha256:4212bb9a9240ec4589be585c60d82a93b8b25de52dc6d7b4d5bfe1be51be3c94
-generated: "2024-07-02T22:05:46.004818548+02:00"
+  version: 0.2.8
+digest: sha256:6d6c206c58c153f986ffa1a52ddd143f37fc14d0ba9818dbf4aa1d8d4ca44ea7
+generated: "2024-07-11T13:31:11.96514+02:00"

--- a/charts/access-request/Chart.yaml
+++ b/charts/access-request/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.10
+version: 1.0.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.7
+  version: 0.2.8
   repository: file://../ghga-common

--- a/charts/access-request/templates/deployment.yml
+++ b/charts/access-request/templates/deployment.yml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       containers:
       - image: "{{ .Values.image.name }}:{{ default .Chart.AppVersion .Values.image.tag }}"
-        {{- include "ghga-common.command-args" (list "ars")  | nindent 8 }}
+        {{- include "ghga-common.command-args" .Values.image  | nindent 8 }}
         name: {{ .Release.Name }}
         securityContext:
           runAsUser: 1000

--- a/charts/access-request/templates/deployment.yml
+++ b/charts/access-request/templates/deployment.yml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       containers:
       - image: "{{ .Values.image.name }}:{{ default .Chart.AppVersion .Values.image.tag }}"
-        {{- include "ghga-common.command-args" .Values.image  | nindent 8 }}
+        {{- include "ghga-common.command-args" .  | nindent 8 }}
         name: {{ .Release.Name }}
         securityContext:
           runAsUser: 1000

--- a/charts/access-request/values.yaml
+++ b/charts/access-request/values.yaml
@@ -6,8 +6,7 @@ horizontalPodAutoscaler:
   averageMemoryUtilization: 75
 image:
   name: "ghga/access-request-service"
-  command:
-    - run-rest
+  command: "cmd --arg1 --arg2"
 podAnnotations: {}
 port: "8080"
 resources:

--- a/charts/access-request/values.yaml
+++ b/charts/access-request/values.yaml
@@ -6,6 +6,8 @@ horizontalPodAutoscaler:
   averageMemoryUtilization: 75
 image:
   name: "ghga/access-request-service"
+  command:
+    - run-rest
 podAnnotations: {}
 port: "8080"
 resources:

--- a/charts/ghga-common/Chart.yaml
+++ b/charts/ghga-common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ghga-common/templates/_command-args.tpl
+++ b/charts/ghga-common/templates/_command-args.tpl
@@ -12,7 +12,5 @@ args:
         [ -f "$f" ] && . "$f";
       done
     fi;
-  {{- range .command }}
-    - {{ . | quote }}
-  {{- end }}
+  - {{ .Values.image.command }}
 {{- end -}}

--- a/charts/ghga-common/templates/_command-args.tpl
+++ b/charts/ghga-common/templates/_command-args.tpl
@@ -12,5 +12,7 @@ args:
         [ -f "$f" ] && . "$f";
       done
     fi;
-    {{ first . }};
+  {{- range .command }}
+    - {{ . | quote }}
+  {{- end }}
 {{- end -}}

--- a/charts/work-package/Chart.lock
+++ b/charts/work-package/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: file://../ghga-common
-  version: 0.2.7
-digest: sha256:4212bb9a9240ec4589be585c60d82a93b8b25de52dc6d7b4d5bfe1be51be3c94
-generated: "2024-07-02T22:20:23.305510579+02:00"
+  version: 0.2.8
+digest: sha256:6d6c206c58c153f986ffa1a52ddd143f37fc14d0ba9818dbf4aa1d8d4ca44ea7
+generated: "2024-07-16T15:45:24.883616+02:00"

--- a/charts/work-package/Chart.yaml
+++ b/charts/work-package/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -19,5 +19,5 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 0.2.7
+  version: 0.2.8
   repository: file://../ghga-common

--- a/charts/work-package/templates/deployment.yml
+++ b/charts/work-package/templates/deployment.yml
@@ -31,7 +31,7 @@ spec:
       {{- end }}
       containers:
       - image: "{{ .Values.image.name }}:{{ default .Chart.AppVersion .Values.image.tag }}"
-        {{- include "ghga-common.command-args" (list "wps run-rest")  | nindent 8 }}
+        {{- include "ghga-common.command-args" .  | nindent 8 }}
         name: {{ .Release.Name }}-rest
         securityContext:
           runAsUser: 1000
@@ -69,7 +69,7 @@ spec:
           readOnly: true
         {{- include "ghga-common.volume-mounts" . | nindent 8 }}
       - image: "{{ .Values.image.name }}:{{ default .Chart.AppVersion .Values.image.tag }}"
-        {{- include "ghga-common.command-args" (list "wps consume-events")  | nindent 8 }}
+        {{- include "ghga-common.command-args" .  | nindent 8 }}
         name: {{ .Release.Name }}-consumer
         securityContext:
           runAsUser: 1000

--- a/charts/work-package/values.yaml
+++ b/charts/work-package/values.yaml
@@ -6,6 +6,7 @@ horizontalPodAutoscaler:
   averageMemoryUtilization: 75
 image:
   name: "ghga/work-package-service"
+  command: "run-rest, consume-events"
 podAnnotations: {}
 port: "8080"
 resources:


### PR DESCRIPTION
I had to alter the deployment file as well

`helm template access-request`
this is the rendered output:
``` yaml 
spec:
      serviceAccountName: release-name
      shareProcessNamespace: false
      containers:
      - image: "ghga/access-request-service:2.0.3"
        command: ["sh", "-c"]
        args:
          - if [ -d "/vault/secrets" ]; then
              for f in /vault/secrets/*; do
                [ -f "$f" ] && . "$f";
              done
            fi;
            - "run-rest"
        name: release-name
        securityContext: