### PR TITLE
Adapt config for file-ingest-service

### DIFF
--- a/charts/file-ingest/Chart.yaml
+++ b/charts/file-ingest/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/file-ingest/values.yaml
+++ b/charts/file-ingest/values.yaml
@@ -63,7 +63,6 @@ parameters:
     vault_path: ekss
     vault_kube_role: null
     workers: 1
-    selected_storage_alias: staging
 
 shareProcessNamespace: false
 kafkaSecrets:


### PR DESCRIPTION
The `selected_storage_alias` setting is not used any more and must be removed.