### PR TITLE
Resolve library chart remotely

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Add charts' dependency repositories
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add ghga https://ghga-de.github.io/charts
 
       - name: Helm Build Dependencies
         run: |

--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Add charts' dependency repositories
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add ghga https://ghga-de.github.io/charts
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0

--- a/README.md
+++ b/README.md
@@ -9,3 +9,33 @@ helm repo add ghga https://ghga-de.github.io/charts
 helm search repo ghga
 helm install my-release ghga/<chart>
 ```
+
+## Developer notes
+
+### Update library chart `ghga-common` locally
+
+If you want to try out an update in the dependency Helm chart `ghga-common`, you need to set the dependency to resolve locally. This can be achieved by specifying the path to the local version of the chart.
+
+In your parent chart's Chart.yaml, update the dependency reference for ghga-common to point to the local file path.
+```yaml
+dependencies:
+  - name: ghga-common
+    version: <version>
+    repository: file://../ghga-common
+```
+
+Verify that the local path ../ghga-common correctly points to the updated ghga-common chart on your file system.
+Run the following command to update dependencies and pull the local chart:
+
+```bash
+helm dependency update
+```
+
+Deploy your parent chart and test the integration with the updated ghga-common chart.
+
+```bash
+helm install <release-name> ./<parent-chart>
+```
+
+> [!IMPORTANT]
+> If you intend to use the updated version of the `ghga-common` chart in a wider or production context, you will need to publish the updated chart to your chart repository before using it in the parent charts.

--- a/charts/access-request/Chart.lock
+++ b/charts/access-request/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts
   version: 0.2.8
-digest: sha256:6d6c206c58c153f986ffa1a52ddd143f37fc14d0ba9818dbf4aa1d8d4ca44ea7
-generated: "2024-07-19T15:14:54.418214684+02:00"
+digest: sha256:0559c10a3c2a32ec0314152222c3232dfff83a61086f074cca673edf778f7ea3
+generated: "2024-07-22T10:36:39.599628383+02:00"

--- a/charts/access-request/Chart.yaml
+++ b/charts/access-request/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -20,4 +20,4 @@ apiVersion: v2
 dependencies:
 - name: ghga-common
   version: 0.2.8
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts

--- a/charts/auth-km-jobs/Chart.lock
+++ b/charts/auth-km-jobs/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts
   version: 0.2.7
-digest: sha256:4212bb9a9240ec4589be585c60d82a93b8b25de52dc6d7b4d5bfe1be51be3c94
-generated: "2024-07-02T22:19:29.135936474+02:00"
+digest: sha256:ed679a7d49f0060477331ad1924579069ee181e320f2019e32d0807d89df87d5
+generated: "2024-07-22T10:44:05.35759123+02:00"

--- a/charts/auth-km-jobs/Chart.yaml
+++ b/charts/auth-km-jobs/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -20,4 +20,4 @@ apiVersion: v2
 dependencies:
 - name: ghga-common
   version: 0.2.7
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts

--- a/charts/auth-service/Chart.lock
+++ b/charts/auth-service/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts
   version: 0.2.8
-digest: sha256:6d6c206c58c153f986ffa1a52ddd143f37fc14d0ba9818dbf4aa1d8d4ca44ea7
-generated: "2024-07-19T15:22:25.618573297+02:00"
+digest: sha256:0559c10a3c2a32ec0314152222c3232dfff83a61086f074cca673edf778f7ea3
+generated: "2024-07-22T10:43:28.898546025+02:00"

--- a/charts/auth-service/Chart.yaml
+++ b/charts/auth-service/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -20,4 +20,4 @@ apiVersion: v2
 dependencies:
 - name: ghga-common
   version: 0.2.8
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts

--- a/charts/data-portal-ui/Chart.lock
+++ b/charts/data-portal-ui/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts
   version: 0.2.8
-digest: sha256:6d6c206c58c153f986ffa1a52ddd143f37fc14d0ba9818dbf4aa1d8d4ca44ea7
-generated: "2024-07-19T12:47:06.445592051+02:00"
+digest: sha256:0559c10a3c2a32ec0314152222c3232dfff83a61086f074cca673edf778f7ea3
+generated: "2024-07-22T10:33:52.299554166+02:00"

--- a/charts/data-portal-ui/Chart.yaml
+++ b/charts/data-portal-ui/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -20,4 +20,4 @@ apiVersion: v2
 dependencies:
 - name: ghga-common
   version: 0.2.8
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts

--- a/charts/download-controller/Chart.lock
+++ b/charts/download-controller/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts
   version: 0.2.8
-digest: sha256:6d6c206c58c153f986ffa1a52ddd143f37fc14d0ba9818dbf4aa1d8d4ca44ea7
-generated: "2024-07-19T12:53:19.21020877+02:00"
+digest: sha256:0559c10a3c2a32ec0314152222c3232dfff83a61086f074cca673edf778f7ea3
+generated: "2024-07-22T10:41:47.979906242+02:00"

--- a/charts/download-controller/Chart.yaml
+++ b/charts/download-controller/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -20,4 +20,4 @@ apiVersion: v2
 dependencies:
 - name: ghga-common
   version: 0.2.8
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts

--- a/charts/encryption-key-store/Chart.lock
+++ b/charts/encryption-key-store/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts
   version: 0.2.8
-digest: sha256:6d6c206c58c153f986ffa1a52ddd143f37fc14d0ba9818dbf4aa1d8d4ca44ea7
-generated: "2024-07-19T12:47:38.438195013+02:00"
+digest: sha256:0559c10a3c2a32ec0314152222c3232dfff83a61086f074cca673edf778f7ea3
+generated: "2024-07-22T10:35:00.758527938+02:00"

--- a/charts/encryption-key-store/Chart.yaml
+++ b/charts/encryption-key-store/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -20,4 +20,4 @@ apiVersion: v2
 dependencies:
 - name: ghga-common
   version: 0.2.8
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts

--- a/charts/file-ingest/Chart.lock
+++ b/charts/file-ingest/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts
   version: 0.2.8
-digest: sha256:6d6c206c58c153f986ffa1a52ddd143f37fc14d0ba9818dbf4aa1d8d4ca44ea7
-generated: "2024-07-19T12:49:42.049122407+02:00"
+digest: sha256:0559c10a3c2a32ec0314152222c3232dfff83a61086f074cca673edf778f7ea3
+generated: "2024-07-22T10:38:11.690203609+02:00"

--- a/charts/file-ingest/Chart.yaml
+++ b/charts/file-ingest/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -20,4 +20,4 @@ apiVersion: v2
 dependencies:
 - name: ghga-common
   version: 0.2.8
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts

--- a/charts/internal-file-registry/Chart.lock
+++ b/charts/internal-file-registry/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts
   version: 0.2.8
-digest: sha256:6d6c206c58c153f986ffa1a52ddd143f37fc14d0ba9818dbf4aa1d8d4ca44ea7
-generated: "2024-07-19T12:46:27.305222917+02:00"
+digest: sha256:0559c10a3c2a32ec0314152222c3232dfff83a61086f074cca673edf778f7ea3
+generated: "2024-07-22T10:33:02.231787119+02:00"

--- a/charts/internal-file-registry/Chart.yaml
+++ b/charts/internal-file-registry/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -20,4 +20,4 @@ apiVersion: v2
 dependencies:
 - name: ghga-common
   version: 0.2.8
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts

--- a/charts/mass/Chart.lock
+++ b/charts/mass/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts
   version: 0.2.8
-digest: sha256:6d6c206c58c153f986ffa1a52ddd143f37fc14d0ba9818dbf4aa1d8d4ca44ea7
-generated: "2024-07-19T12:49:13.786090609+02:00"
+digest: sha256:0559c10a3c2a32ec0314152222c3232dfff83a61086f074cca673edf778f7ea3
+generated: "2024-07-22T10:37:24.935117722+02:00"

--- a/charts/mass/Chart.yaml
+++ b/charts/mass/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -20,4 +20,4 @@ apiVersion: v2
 dependencies:
 - name: ghga-common
   version: 0.2.8
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts

--- a/charts/metadata-repository/Chart.lock
+++ b/charts/metadata-repository/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts
   version: 0.2.7
-digest: sha256:4212bb9a9240ec4589be585c60d82a93b8b25de52dc6d7b4d5bfe1be51be3c94
-generated: "2024-07-02T22:19:40.807581345+02:00"
+digest: sha256:ed679a7d49f0060477331ad1924579069ee181e320f2019e32d0807d89df87d5
+generated: "2024-07-22T10:44:42.321019816+02:00"

--- a/charts/metadata-repository/Chart.yaml
+++ b/charts/metadata-repository/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10
+version: 0.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -20,4 +20,4 @@ apiVersion: v2
 dependencies:
 - name: ghga-common
   version: 0.2.7
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts

--- a/charts/metadata-search/Chart.lock
+++ b/charts/metadata-search/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts
   version: 0.2.7
-digest: sha256:4212bb9a9240ec4589be585c60d82a93b8b25de52dc6d7b4d5bfe1be51be3c94
-generated: "2024-07-02T22:19:04.225989303+02:00"
+digest: sha256:ed679a7d49f0060477331ad1924579069ee181e320f2019e32d0807d89df87d5
+generated: "2024-07-22T10:42:35.960579618+02:00"

--- a/charts/metadata-search/Chart.yaml
+++ b/charts/metadata-search/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10
+version: 0.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -20,4 +20,4 @@ apiVersion: v2
 dependencies:
 - name: ghga-common
   version: 0.2.7
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts

--- a/charts/metldata/Chart.lock
+++ b/charts/metldata/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts
   version: 0.2.8
-digest: sha256:6d6c206c58c153f986ffa1a52ddd143f37fc14d0ba9818dbf4aa1d8d4ca44ea7
-generated: "2024-07-19T15:25:30.568295991+02:00"
+digest: sha256:0559c10a3c2a32ec0314152222c3232dfff83a61086f074cca673edf778f7ea3
+generated: "2024-07-22T10:48:14.012464113+02:00"

--- a/charts/metldata/Chart.yaml
+++ b/charts/metldata/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.19
+version: 1.0.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -20,4 +20,4 @@ apiVersion: v2
 dependencies:
 - name: ghga-common
   version: 0.2.8
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts

--- a/charts/notification-orchestration/Chart.lock
+++ b/charts/notification-orchestration/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts
   version: 0.2.8
-digest: sha256:6d6c206c58c153f986ffa1a52ddd143f37fc14d0ba9818dbf4aa1d8d4ca44ea7
-generated: "2024-07-19T12:51:06.862492267+02:00"
+digest: sha256:0559c10a3c2a32ec0314152222c3232dfff83a61086f074cca673edf778f7ea3
+generated: "2024-07-22T10:39:25.345854019+02:00"

--- a/charts/notification-orchestration/Chart.yaml
+++ b/charts/notification-orchestration/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -20,4 +20,4 @@ apiVersion: v2
 dependencies:
 - name: ghga-common
   version: 0.2.8
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts

--- a/charts/notification/Chart.lock
+++ b/charts/notification/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts
   version: 0.2.8
-digest: sha256:6d6c206c58c153f986ffa1a52ddd143f37fc14d0ba9818dbf4aa1d8d4ca44ea7
-generated: "2024-07-19T12:52:06.249123289+02:00"
+digest: sha256:0559c10a3c2a32ec0314152222c3232dfff83a61086f074cca673edf778f7ea3
+generated: "2024-07-22T10:40:14.19680689+02:00"

--- a/charts/notification/Chart.yaml
+++ b/charts/notification/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -20,4 +20,4 @@ apiVersion: v2
 dependencies:
 - name: ghga-common
   version: 0.2.8
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts

--- a/charts/remotebackup/Chart.lock
+++ b/charts/remotebackup/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts
   version: 0.2.7
-digest: sha256:4212bb9a9240ec4589be585c60d82a93b8b25de52dc6d7b4d5bfe1be51be3c94
-generated: "2024-07-02T22:20:12.265671122+02:00"
+digest: sha256:ed679a7d49f0060477331ad1924579069ee181e320f2019e32d0807d89df87d5
+generated: "2024-07-22T10:48:32.533133178+02:00"

--- a/charts/remotebackup/Chart.yaml
+++ b/charts/remotebackup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -26,4 +26,4 @@ appVersion: "0.0.1"
 dependencies:
 - name: ghga-common
   version: 0.2.7
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts

--- a/charts/test-oidc-provider/Chart.lock
+++ b/charts/test-oidc-provider/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts
   version: 0.2.8
-digest: sha256:6d6c206c58c153f986ffa1a52ddd143f37fc14d0ba9818dbf4aa1d8d4ca44ea7
-generated: "2024-07-19T15:26:33.156325707+02:00"
+digest: sha256:0559c10a3c2a32ec0314152222c3232dfff83a61086f074cca673edf778f7ea3
+generated: "2024-07-22T10:48:23.350309908+02:00"

--- a/charts/test-oidc-provider/Chart.yaml
+++ b/charts/test-oidc-provider/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.10
+version: 1.0.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -20,4 +20,4 @@ apiVersion: v2
 dependencies:
 - name: ghga-common
   version: 0.2.8
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts

--- a/charts/well-known-value/Chart.lock
+++ b/charts/well-known-value/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts
   version: 0.2.8
-digest: sha256:6d6c206c58c153f986ffa1a52ddd143f37fc14d0ba9818dbf4aa1d8d4ca44ea7
-generated: "2024-07-19T12:52:41.604953316+02:00"
+digest: sha256:0559c10a3c2a32ec0314152222c3232dfff83a61086f074cca673edf778f7ea3
+generated: "2024-07-22T10:41:01.328299497+02:00"

--- a/charts/well-known-value/Chart.yaml
+++ b/charts/well-known-value/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -20,4 +20,4 @@ apiVersion: v2
 dependencies:
 - name: ghga-common
   version: 0.2.8
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts

--- a/charts/work-package/Chart.lock
+++ b/charts/work-package/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts
   version: 0.2.8
-digest: sha256:6d6c206c58c153f986ffa1a52ddd143f37fc14d0ba9818dbf4aa1d8d4ca44ea7
-generated: "2024-07-19T15:28:11.970418195+02:00"
+digest: sha256:0559c10a3c2a32ec0314152222c3232dfff83a61086f074cca673edf778f7ea3
+generated: "2024-07-22T10:48:41.735725116+02:00"

--- a/charts/work-package/Chart.yaml
+++ b/charts/work-package/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.9
+version: 1.0.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -20,4 +20,4 @@ apiVersion: v2
 dependencies:
 - name: ghga-common
   version: 0.2.8
-  repository: file://../ghga-common
+  repository: https://ghga-de.github.io/charts


### PR DESCRIPTION
## Objective

Locally referenced library charts don't resolve their dependencies [correctly](https://github.com/helm/helm/issues/2247). This PR updates the charts dependencies to resolve the library chart remotely.

This has implications for development

- to test a library chart release locally, you'll need to change the dependency to local file resolver
- a new release needs to be published before publishing parent charts