### PR TITLE
FIS update

### DIFF
--- a/charts/file-ingest/Chart.yaml
+++ b/charts/file-ingest/Chart.yaml
@@ -5,13 +5,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.2
+version: 3.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.1.0"
+appVersion: "4.0.0"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.

--- a/charts/file-ingest/values.yaml
+++ b/charts/file-ingest/values.yaml
@@ -22,7 +22,6 @@ parameters:
     db_name: fis
     service_instance_id: rest.1
     service_name: fis
-    source_bucket_id: staging
     token_hashes: []
     vault_url: http://vault:8200
     vault_verify: false


### PR DESCRIPTION
- file-ingest-service's version is upgraded to 4.0.0
- `source_bucket_id` is removed from fis-ingest values since it is not a part of [FIS config_schema.json](https://github.com/ghga-de/file-services-backend/blob/main/services/fis/config_schema.json) anymore.