### PR TITLE
Add Dataset Information and Purge Controller service charts

### DIFF
--- a/charts/dataset-information/Chart.lock
+++ b/charts/dataset-information/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: ghga-common
+  repository: https://ghga-de.github.io/charts
+  version: 1.0.8
+digest: sha256:940b554aec00a2ae2e269b75f9c59c30d596544bf5684f3441870fc2614d6784
+generated: "2024-10-24T10:43:59.961558+02:00"

--- a/charts/dataset-information/Chart.lock
+++ b/charts/dataset-information/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ghga-common
   repository: https://ghga-de.github.io/charts
-  version: 1.0.8
-digest: sha256:940b554aec00a2ae2e269b75f9c59c30d596544bf5684f3441870fc2614d6784
-generated: "2024-10-24T10:43:59.961558+02:00"
+  version: 1.2.0
+digest: sha256:276a8884394ef2839b1182f4c795f6217c875225cf3d18ee480976cf6d3d5b0a
+generated: "2024-10-24T11:07:37.463886+02:00"

--- a/charts/dataset-information/Chart.yaml
+++ b/charts/dataset-information/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 
 dependencies:
 - name: ghga-common
-  version: 1.0.8
+  version: 1.2.0
   repository: https://ghga-de.github.io/charts
   import-values:
   - defaults

--- a/charts/dataset-information/Chart.yaml
+++ b/charts/dataset-information/Chart.yaml
@@ -1,5 +1,5 @@
-name: purge-controller
-description: Purge Controller Service
+name: dataset-information
+description: Dataset Information Service
 type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
@@ -11,7 +11,7 @@ version: 1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.2"
+appVersion: "1.1.0"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.

--- a/charts/dataset-information/Chart.yaml
+++ b/charts/dataset-information/Chart.yaml
@@ -1,35 +1,25 @@
-name: file-services-backend
-description: Microservices for file-service backend
+name: purge-controller
+description: Purge Controller Service
 type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.0
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.0"
+appVersion: "2.0.2"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.
 apiVersion: v2
 
 dependencies:
-- name: download-controller
-  version: 2.0.9
+- name: ghga-common
+  version: 1.0.8
   repository: https://ghga-de.github.io/charts
-- name: encryption-key-store
-  version: 2.0.6
-  repository: https://ghga-de.github.io/charts
-- name: file-ingest
-  version: 3.0.3
-  repository: https://ghga-de.github.io/charts
-- name: internal-file-registry
-  version: 2.0.8
-  repository: https://ghga-de.github.io/charts
-- name: purge-controller-service
-  version: 1.0.0
-  repository: https://ghga-de.github.io/charts
+  import-values:
+  - defaults

--- a/charts/dataset-information/templates/configmap.yml
+++ b/charts/dataset-information/templates/configmap.yml
@@ -1,0 +1,1 @@
+{{- include "ghga-common.configmap" . }}

--- a/charts/dataset-information/templates/deployment.yml
+++ b/charts/dataset-information/templates/deployment.yml
@@ -1,0 +1,1 @@
+{{- include "ghga-common.deployment" . }}

--- a/charts/dataset-information/templates/horizontalpodautoscaler.yml
+++ b/charts/dataset-information/templates/horizontalpodautoscaler.yml
@@ -1,0 +1,1 @@
+{{- include "ghga-common.hpa" . }}

--- a/charts/dataset-information/templates/ingress.yml
+++ b/charts/dataset-information/templates/ingress.yml
@@ -1,0 +1,1 @@
+{{- include "ghga-common.ingress" . }}

--- a/charts/dataset-information/templates/mapping.yml
+++ b/charts/dataset-information/templates/mapping.yml
@@ -1,0 +1,1 @@
+{{- include "ghga-common.mapping" . }}

--- a/charts/dataset-information/templates/service.yml
+++ b/charts/dataset-information/templates/service.yml
@@ -1,0 +1,1 @@
+{{- include "ghga-common.service" . }}

--- a/charts/dataset-information/templates/serviceaccount.yml
+++ b/charts/dataset-information/templates/serviceaccount.yml
@@ -1,0 +1,1 @@
+{{- include "ghga-common.serviceaccount" . }}

--- a/charts/dataset-information/values.yaml
+++ b/charts/dataset-information/values.yaml
@@ -1,0 +1,63 @@
+image:
+  repository: "ghga/dataset-information-service"
+
+config_prefix: dins
+
+parameters:
+  default:
+    host: 0.0.0.0
+    db_connection_str: null
+    db_name: dins
+    service_instance_id: rest.1
+    service_name: dins
+    token_hashes: []
+  rest:
+    service_instance_id: 'rest.1'
+  consumer:
+    service_instance_id: 'consumer.1'
+
+containers:
+- name: rest
+  type: "rest"
+  cmd: dins run-rest
+  config:
+    name: parameters-rest
+    key: parameters-rest
+- name: consumer
+  type: "consumer"
+  cmd: dins consume-events
+  config:
+    name: parameters-consumer
+    key: parameters-consumer
+
+
+topics:
+
+  fileRegisteredEvent:
+    topic:
+      name: file_registered_event_topic
+      value: internal_registrations
+    type:
+      name: file_registered_event_type
+      value: internal_file_registered
+
+  filesToDelete:
+    topic:
+      name: files_to_delete_topic
+      value: purges
+
+  DatasetUpsertionEvent:
+    topic:
+      name: dataset_event_topic
+      value: metadata_datasets
+    type:
+      name: dataset_upsertion_event_type
+      value: dataset_created
+  
+  DatasetDeletionEvent:
+    topic:
+      name: dataset_event_topic
+      value: metadata_datasets
+    type:
+      name: dataset_deletion_event_type
+      value: dataset_deleted

--- a/charts/dataset-information/values.yaml
+++ b/charts/dataset-information/values.yaml
@@ -54,7 +54,7 @@ topics:
       name: dataset_upsertion_event_type
       value: dataset_created
   
-  DatasetDeletionEvent:
+  datasetDeletionEvent:
     topic:
       name: dataset_event_topic
       value: metadata_datasets

--- a/charts/dataset-information/values.yaml
+++ b/charts/dataset-information/values.yaml
@@ -46,7 +46,7 @@ topics:
       name: files_to_delete_topic
       value: purges
 
-  DatasetUpsertionEvent:
+  datasetUpsertionEvent:
     topic:
       name: dataset_event_topic
       value: metadata_datasets

--- a/charts/dataset-information/values.yaml
+++ b/charts/dataset-information/values.yaml
@@ -53,7 +53,6 @@ topics:
     type:
       name: dataset_upsertion_event_type
       value: dataset_created
-  
   datasetDeletionEvent:
     topic:
       name: dataset_event_topic

--- a/charts/file-services-backend/Chart.yaml
+++ b/charts/file-services-backend/Chart.yaml
@@ -30,6 +30,3 @@ dependencies:
 - name: internal-file-registry
   version: 2.0.8
   repository: https://ghga-de.github.io/charts
-- name: purge-controller-service
-  version: 1.0.0
-  repository: https://ghga-de.github.io/charts

--- a/charts/purge-controller/Chart.lock
+++ b/charts/purge-controller/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: ghga-common
+  repository: https://ghga-de.github.io/charts
+  version: 1.2.0
+digest: sha256:276a8884394ef2839b1182f4c795f6217c875225cf3d18ee480976cf6d3d5b0a
+generated: "2024-10-24T10:43:49.460627+02:00"

--- a/charts/purge-controller/Chart.yaml
+++ b/charts/purge-controller/Chart.yaml
@@ -1,35 +1,25 @@
-name: file-services-backend
-description: Microservices for file-service backend
+name: file-ingest
+description: A lightweight service to propagate file upload metadata to the GHGA file backend services
 type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.0
+version: 3.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.0"
+appVersion: "4.0.0"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.
 apiVersion: v2
 
 dependencies:
-- name: download-controller
-  version: 2.0.9
+- name: ghga-common
+  version: 1.2.0
   repository: https://ghga-de.github.io/charts
-- name: encryption-key-store
-  version: 2.0.6
-  repository: https://ghga-de.github.io/charts
-- name: file-ingest
-  version: 3.0.3
-  repository: https://ghga-de.github.io/charts
-- name: internal-file-registry
-  version: 2.0.8
-  repository: https://ghga-de.github.io/charts
-- name: purge-controller-service
-  version: 1.0.0
-  repository: https://ghga-de.github.io/charts
+  import-values:
+  - defaults

--- a/charts/purge-controller/Chart.yaml
+++ b/charts/purge-controller/Chart.yaml
@@ -1,17 +1,17 @@
-name: file-ingest
-description: A lightweight service to propagate file upload metadata to the GHGA file backend services
+name: purge-controller
+description: Purge Controller Service
 type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.0
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "4.0.0"
+appVersion: "2.0.2"
 
 # The major version of the API. Minor versions and patches are not relevant as they do not
 # introduce breaking changes.

--- a/charts/purge-controller/templates/configmap.yml
+++ b/charts/purge-controller/templates/configmap.yml
@@ -1,0 +1,1 @@
+{{- include "ghga-common.configmap" . }}

--- a/charts/purge-controller/templates/deployment.yml
+++ b/charts/purge-controller/templates/deployment.yml
@@ -1,0 +1,1 @@
+{{- include "ghga-common.deployment" . }}

--- a/charts/purge-controller/templates/horizontalpodautoscaler.yml
+++ b/charts/purge-controller/templates/horizontalpodautoscaler.yml
@@ -1,0 +1,1 @@
+{{- include "ghga-common.hpa" . }}

--- a/charts/purge-controller/templates/ingress.yml
+++ b/charts/purge-controller/templates/ingress.yml
@@ -1,0 +1,1 @@
+{{- include "ghga-common.ingress" . }}

--- a/charts/purge-controller/templates/mapping.yml
+++ b/charts/purge-controller/templates/mapping.yml
@@ -1,0 +1,1 @@
+{{- include "ghga-common.mapping" . }}

--- a/charts/purge-controller/templates/service.yml
+++ b/charts/purge-controller/templates/service.yml
@@ -1,0 +1,1 @@
+{{- include "ghga-common.service" . }}

--- a/charts/purge-controller/templates/serviceaccount.yml
+++ b/charts/purge-controller/templates/serviceaccount.yml
@@ -1,0 +1,1 @@
+{{- include "ghga-common.serviceaccount" . }}

--- a/charts/purge-controller/values.yaml
+++ b/charts/purge-controller/values.yaml
@@ -26,4 +26,3 @@ topics:
     topic:
       name: files_to_delete_topic
       value: purges
-

--- a/charts/purge-controller/values.yaml
+++ b/charts/purge-controller/values.yaml
@@ -1,0 +1,29 @@
+image:
+  repository: "ghga/purge-controller-service"
+
+config_prefix: pcs
+
+parameters:
+  default:
+    host: 0.0.0.0
+    db_connection_str: null
+    db_name: pcs
+    service_instance_id: rest.1
+    token_hashes: []
+
+containers:
+- name: rest
+  type: "rest"
+  cmd: pcs run-rest
+  config:
+    name: parameters
+    key: parameters
+
+
+topics:
+
+  filesToDelete:
+    topic:
+      name: files_to_delete_topic
+      value: purges
+


### PR DESCRIPTION
This PR adds two new services. [Dataset Information Service](https://github.com/ghga-de/dataset-information-service) and [Purge Controller Service](https://github.com/ghga-de/file-services-backend/tree/main/services/pcs)