### PR TITLE
Add an HTML table for version history

### DIFF
--- a/table.html
+++ b/table.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>YAML Data Table</title>
+    <style>
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        table, th, td {
+            border: 1px solid black;
+        }
+        th, td {
+            padding: 8px;
+            text-align: left;
+        }
+        th {
+            background-color: #f2f2f2;
+        }
+        #search-input {
+            margin-bottom: 20px;
+            padding: 8px;
+            width: 300px;
+        }
+    </style>
+</head>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js"></script>
+
+<body>
+    <h1>Chart Index</h1>
+    <input type="text" id="search-input" placeholder="Search..." onkeyup="filterTable()">
+    <div id="yaml-table"></div>
+    <script>
+        async function fetchYamlAndGenerateTable(url) {
+            try {
+                const response = await fetch(url);
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                const yamlText = await response.text();
+                const data = jsyaml.load(yamlText); // Parse YAML to JavaScript object
+    
+                document.getElementById('yaml-table').appendChild(generateTable(data));
+            } catch (error) {
+                console.error('Error fetching or parsing the YAML file:', error);
+            }
+        }    
+        function generateTable(data) {
+            const table = document.createElement('table');
+            table.id = "data-table";
+            const thead = document.createElement('thead');
+            const headerRow = document.createElement('tr');
+            const headers = ["Name", "Version", "App Version", "Created"];
+            
+            headers.forEach(headerText => {
+                const th = document.createElement('th');
+                th.textContent = headerText;
+                headerRow.appendChild(th);
+            });
+            thead.appendChild(headerRow);
+            table.appendChild(thead);
+
+            const tbody = document.createElement('tbody');
+            for (let entryKey in data.entries) {
+                data.entries[entryKey].forEach(entry => {
+                    const row = document.createElement('tr');
+                    
+                    const nameCell = document.createElement('td');
+                    nameCell.textContent = entry.name;
+                    row.appendChild(nameCell);
+
+                    const versionCell = document.createElement('td');
+                    versionCell.textContent = entry.version;
+                    row.appendChild(versionCell);
+
+                    const appVersionCell = document.createElement('td');
+                    appVersionCell.textContent = entry.appVersion;
+                    row.appendChild(appVersionCell);
+
+                    const createdCell = document.createElement('td');
+                    const createdDate = new Date(entry.created);
+                    createdCell.textContent = createdDate.toLocaleDateString() + ' ' + createdDate.toLocaleTimeString();
+                    row.appendChild(createdCell);
+
+                    tbody.appendChild(row);
+                });
+            }
+
+            table.appendChild(tbody);
+            return table;
+        }
+
+        function filterTable() {
+            const input = document.getElementById('search-input');
+            const filter = input.value.toLowerCase();
+            const table = document.getElementById('data-table');
+            const rows = table.getElementsByTagName('tr');
+
+            for (let i = 1; i < rows.length; i++) { // Start from 1 to skip header row
+                let row = rows[i];
+                let textContent = row.textContent.toLowerCase();
+                if (textContent.includes(filter)) {
+                    row.style.display = "";
+                } else {
+                    row.style.display = "none";
+                }
+            }
+        }
+        fetchYamlAndGenerateTable('https://ghga-de.github.io/charts/index.yaml');
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a simple HTML page to the GitHub pages. This HTML page reads the `index.yaml` and creates a simple searchable table including the version history of all the tagged Charts. 

I've created this page to quickly map the service versions vs. Chart versions, track the deployed versions in the devops-hub, and track whether the latest service versions are already added. It could also be useful to include it in the repo.

Table looks like:
![image](https://github.com/user-attachments/assets/dd537e0c-622a-49f5-ba8c-b564f41ad4be)
