### PR TITLE
Revert topic names, update deletion topic

### DIFF
--- a/central kafka reference.txt
+++ b/central kafka reference.txt
@@ -25,26 +25,26 @@ access_request_denied_type: access_request_denied
 file_deletion_request_topic: purges
 file_deletion_request_type: file_deletion_requested
 
-file_internally_registered_topic: file-internal-registrations
+file_internally_registered_topic: internal-registrations
 file_internally_registered_type: internal_file_registered
 
-file_registered_for_download_topic: file-downloads
+file_registered_for_download_topic: downloads
 file_registered_for_download_type: drs_object_registered
 
 # this one (file deleted) is different for each service. The one below is for the DCS
-file_deleted_topic: file-downloads
+file_deleted_topic: file-deletions
 file_deleted_type: drs_object_deleted
 
-download_served_topic: file-downloads
+download_served_topic: downloads
 download_served_type: drs_object_served
 
-files_to_stage_topic: file-staging-requests
+files_to_stage_topic: staging-requests
 files_to_stage_type: file_staging_requested
 
-file_staged_topic: internal-staged-files
+file_staged_topic: staged-files
 file_staged_type: internal_file_staged
 
-file_interrogations_topic: file-interrogations
+file_interrogations_topic: interrogations
 interrogation_success_type: file_interrogation_success
 
 file_upload_topic: file-uploads

--- a/charts/access-request/Chart.yaml
+++ b/charts/access-request/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/auth-service/Chart.yaml
+++ b/charts/auth-service/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/data-portal-ui/Chart.yaml
+++ b/charts/data-portal-ui/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/dataset-information/Chart.yaml
+++ b/charts/dataset-information/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/dataset-information/values.yaml
+++ b/charts/dataset-information/values.yaml
@@ -29,7 +29,7 @@ _topics:
     # as consumer
     topic:
       name: file_internally_registered_topic
-      value: file-internal-registrations
+      value: internal-registrations
     types:
       - name: file_internally_registered_type
         value: internal_file_registered

--- a/charts/dead-letter-queue/Chart.yaml
+++ b/charts/dead-letter-queue/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/download-controller/Chart.yaml
+++ b/charts/download-controller/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/download-controller/values.yaml
+++ b/charts/download-controller/values.yaml
@@ -39,7 +39,7 @@ _topics:
     # as producer
     topic:
       name: file_registered_for_download_topic
-      value: file-downloads
+      value: downloads
     types:
       - name: file_registered_for_download_type
         value: drs_object_registered
@@ -50,7 +50,7 @@ _topics:
     # as producer
     topic:
       name: file_deleted_topic
-      value: file-downloads
+      value: file-deletions
     types:
       - name: file_deleted_type
         value: drs_object_deleted
@@ -61,7 +61,7 @@ _topics:
     # as consumer
     topic:
       name: file_internally_registered_topic
-      value: file-internal-registrations
+      value: internal-registrations
     types:
       - name: file_internally_registered_type
         value: internal_file_registered
@@ -83,7 +83,7 @@ _topics:
     # as producer
     topic:
       name: download_served_topic
-      value: file-downloads
+      value: downloads
     types:
       - name: download_served_type
         value: drs_object_served
@@ -94,7 +94,7 @@ _topics:
     # as producer
     topic:
       name: files_to_stage_topic
-      value: file-staging-requests  # must differ from 'downloads' topic vals
+      value: staging-requests  # must differ from 'downloads' topic vals
     type:
       name: files_to_stage_type
       value: file_staging_requested

--- a/charts/encryption-key-store/Chart.yaml
+++ b/charts/encryption-key-store/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/file-ingest/Chart.yaml
+++ b/charts/file-ingest/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/file-ingest/values.yaml
+++ b/charts/file-ingest/values.yaml
@@ -33,7 +33,7 @@ _topics:
     # as producer
     topic:
       name: file_interrogations_topic
-      value: file-interrogations
+      value: interrogations
     types:
       - name: interrogation_success_type
         value: file_interrogation_success

--- a/charts/internal-file-registry/Chart.yaml
+++ b/charts/internal-file-registry/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/internal-file-registry/values.yaml
+++ b/charts/internal-file-registry/values.yaml
@@ -30,7 +30,7 @@ _topics:
     # as producer
     topic:
       name: file_deleted_topic
-      value: file-downloads
+      value: file-deletions
     types:
       - name: file_deleted_type
         value: internal_file_deleted
@@ -41,7 +41,7 @@ _topics:
     # as producer
     topic:
       name: file_internally_registered_topic
-      value: file-internal-registrations
+      value: internal-registrations
     types:
       - name: file_internally_registered_type
         value: internal_file_registered
@@ -52,7 +52,7 @@ _topics:
     # as producer
     topic:
       name: file_staged_topic
-      value: internal-staged-files
+      value: staged-files
     types:
       - name: file_staged_type
         value: internal_file_staged
@@ -74,7 +74,7 @@ _topics:
     # as consumer
     topic:
       name: files_to_stage_topic
-      value: file-staging-requests
+      value: staging-requests
     type:
       name: files_to_stage_type
       value: file_staging_requested

--- a/charts/mass/Chart.yaml
+++ b/charts/mass/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/metldata/Chart.yaml
+++ b/charts/metldata/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/notification-orchestration/Chart.yaml
+++ b/charts/notification-orchestration/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/notification/Chart.yaml
+++ b/charts/notification/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/purge-controller/Chart.yaml
+++ b/charts/purge-controller/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/registry/Chart.yaml
+++ b/charts/registry/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/reverse-transpiler/Chart.yaml
+++ b/charts/reverse-transpiler/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/state-management/Chart.yaml
+++ b/charts/state-management/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/test-oidc-provider/Chart.yaml
+++ b/charts/test-oidc-provider/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/upload-controller/Chart.yaml
+++ b/charts/upload-controller/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/upload-controller/values.yaml
+++ b/charts/upload-controller/values.yaml
@@ -31,7 +31,7 @@ _topics:
     # as producer
     topic:
       name: file_interrogations_topic
-      value: file-interrogations
+      value: interrogations
     types:
       - name: interrogation_success_type
         value: file_interrogation_success
@@ -44,7 +44,7 @@ _topics:
     # as consumer
     topic:
       name: file_internally_registered_topic
-      value: file-internal-registrations
+      value: internal-registrations
     types:
       - name: file_internally_registered_type
         value: internal_file_registered

--- a/charts/well-known-value/Chart.yaml
+++ b/charts/well-known-value/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/work-package/Chart.yaml
+++ b/charts/work-package/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/template/Chart.yaml
+++ b/src/template/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 24.4.3
+version: 24.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/values/dataset-information.yaml
+++ b/src/values/dataset-information.yaml
@@ -29,7 +29,7 @@ _topics:
     # as consumer
     topic:
       name: file_internally_registered_topic
-      value: file-internal-registrations
+      value: internal-registrations
     types:
       - name: file_internally_registered_type
         value: internal_file_registered

--- a/src/values/download-controller.yaml
+++ b/src/values/download-controller.yaml
@@ -39,7 +39,7 @@ _topics:
     # as producer
     topic:
       name: file_registered_for_download_topic
-      value: file-downloads
+      value: downloads
     types:
       - name: file_registered_for_download_type
         value: drs_object_registered
@@ -50,7 +50,7 @@ _topics:
     # as producer
     topic:
       name: file_deleted_topic
-      value: file-downloads
+      value: file-deletions
     types:
       - name: file_deleted_type
         value: drs_object_deleted
@@ -61,7 +61,7 @@ _topics:
     # as consumer
     topic:
       name: file_internally_registered_topic
-      value: file-internal-registrations
+      value: internal-registrations
     types:
       - name: file_internally_registered_type
         value: internal_file_registered
@@ -83,7 +83,7 @@ _topics:
     # as producer
     topic:
       name: download_served_topic
-      value: file-downloads
+      value: downloads
     types:
       - name: download_served_type
         value: drs_object_served
@@ -94,7 +94,7 @@ _topics:
     # as producer
     topic:
       name: files_to_stage_topic
-      value: file-staging-requests  # must differ from 'downloads' topic vals
+      value: staging-requests  # must differ from 'downloads' topic vals
     type:
       name: files_to_stage_type
       value: file_staging_requested

--- a/src/values/file-ingest.yaml
+++ b/src/values/file-ingest.yaml
@@ -33,7 +33,7 @@ _topics:
     # as producer
     topic:
       name: file_interrogations_topic
-      value: file-interrogations
+      value: interrogations
     types:
       - name: interrogation_success_type
         value: file_interrogation_success

--- a/src/values/internal-file-registry.yaml
+++ b/src/values/internal-file-registry.yaml
@@ -30,7 +30,7 @@ _topics:
     # as producer
     topic:
       name: file_deleted_topic
-      value: file-downloads
+      value: file-deletions
     types:
       - name: file_deleted_type
         value: internal_file_deleted
@@ -41,7 +41,7 @@ _topics:
     # as producer
     topic:
       name: file_internally_registered_topic
-      value: file-internal-registrations
+      value: internal-registrations
     types:
       - name: file_internally_registered_type
         value: internal_file_registered
@@ -52,7 +52,7 @@ _topics:
     # as producer
     topic:
       name: file_staged_topic
-      value: internal-staged-files
+      value: staged-files
     types:
       - name: file_staged_type
         value: internal_file_staged
@@ -74,7 +74,7 @@ _topics:
     # as consumer
     topic:
       name: files_to_stage_topic
-      value: file-staging-requests
+      value: staging-requests
     type:
       name: files_to_stage_type
       value: file_staging_requested

--- a/src/values/upload-controller.yaml
+++ b/src/values/upload-controller.yaml
@@ -31,7 +31,7 @@ _topics:
     # as producer
     topic:
       name: file_interrogations_topic
-      value: file-interrogations
+      value: interrogations
     types:
       - name: interrogation_success_type
         value: file_interrogation_success
@@ -44,7 +44,7 @@ _topics:
     # as consumer
     topic:
       name: file_internally_registered_topic
-      value: file-internal-registrations
+      value: internal-registrations
     types:
       - name: file_internally_registered_type
         value: internal_file_registered


### PR DESCRIPTION
The previous renaming of the topics are reverted and original names are back. 

For the `file_deleted_topic` I followed @TheByronHimes suggestion and change it to `file-deletions`